### PR TITLE
Add dodge timer and invulnerability helper

### DIFF
--- a/client/app/src/main/java/com/tavuc/controllers/PlayerMovementController.java
+++ b/client/app/src/main/java/com/tavuc/controllers/PlayerMovementController.java
@@ -15,6 +15,7 @@ public class PlayerMovementController {
     private MovementState currentState = MovementState.IDLE;
     private boolean isSliding = false;
     private double slideTimer = 0.0;
+    private double dodgeTimer = 0.0;
     private final Vector2D lastInputDirection = new Vector2D();
 
     /**
@@ -47,9 +48,19 @@ public class PlayerMovementController {
             }
         }
 
+        // Update dodge timer
+        if (dodgeTimer > 0) {
+            dodgeTimer -= deltaTime;
+            if (dodgeTimer < 0) {
+                dodgeTimer = 0;
+            }
+        }
+
         // Update state
         if (isSliding) {
             currentState = MovementState.SLIDING;
+        } else if (dodgeTimer > 0) {
+            currentState = MovementState.DODGING;
         } else if (velocity.length() > 0.1) {
             currentState = MovementState.RUNNING;
         } else {
@@ -87,6 +98,7 @@ public class PlayerMovementController {
     public void dodge() {
         velocity.set(lastInputDirection.getX() * maxSpeed * 1.5, lastInputDirection.getY() * maxSpeed * 1.5);
         currentState = MovementState.DODGING;
+        dodgeTimer = 0.2; // duration of dodge in seconds
         if (Client.currentGamePanel != null) {
             Client.currentGamePanel.triggerScreenShake(6, 5);
         }

--- a/client/app/src/main/java/com/tavuc/managers/InputManager.java
+++ b/client/app/src/main/java/com/tavuc/managers/InputManager.java
@@ -121,7 +121,7 @@ public class InputManager implements KeyListener {
                 inputBuffer.registerInput(KeyBinding.DODGE);
                 if (player != null) {
                     player.getMovementController().dodge();
-                    player.startInvulnerability(0.5);
+                    player.startDodgeInvulnerability(0.5);
                 }
             }
             updatePlayerMovementInput();
@@ -193,7 +193,7 @@ public class InputManager implements KeyListener {
                     break;
                 case DODGE:
                     player.getMovementController().dodge();
-                    player.startInvulnerability(0.5);
+                    player.startDodgeInvulnerability(0.5);
                     break;
                 default:
                     // movement commands are handled below using key states

--- a/client/app/src/main/java/com/tavuc/models/entities/Player.java
+++ b/client/app/src/main/java/com/tavuc/models/entities/Player.java
@@ -105,6 +105,13 @@ public class Player extends Entity {
         this.invulnTimer = duration;
     }
 
+    /**
+     * Invulnerability specifically triggered by a dodge action.
+     */
+    public void startDodgeInvulnerability(double duration) {
+        startInvulnerability(duration);
+    }
+
     public float getDamageEffect() {
         return damageEffect;
     }


### PR DESCRIPTION
## Summary
- add a `dodgeTimer` to `PlayerMovementController`
- end dodge state when the timer expires
- expose `startDodgeInvulnerability` on `Player`
- trigger dodge invulnerability through the player when dodging

## Testing
- `./run_all_tests.sh`

------
https://chatgpt.com/codex/tasks/task_e_6844ef94b594833190ab996534158079