### PR TITLE
Add lightsaber charge lunge and projectile reflection

### DIFF
--- a/client/app/src/test/java/com/tavuc/weapons/LightsaberTest.java
+++ b/client/app/src/test/java/com/tavuc/weapons/LightsaberTest.java
@@ -10,18 +10,32 @@ import static org.junit.Assert.*;
  */
 public class LightsaberTest {
     @Test
-    public void comboCyclesThroughSwingPatterns() {
+    public void chargeLungeChangesPosition() {
         Player dummy = new Player(1, "tester");
         WeaponStats stats = new WeaponStats(1, 1, 0.1);
         Lightsaber saber = new Lightsaber(LightsaberCrystal.BLUE, 1.0, stats);
 
+        Vector2D target = new Vector2D(dummy.getX() + 10, dummy.getY());
+
         assertTrue(saber.canAttack());
-        saber.primaryAttack(dummy, new Vector2D());
-        assertFalse(saber.canAttack());
-        // simulate cooldown expiry
-        try { Thread.sleep(120); } catch (InterruptedException e) {}
+        saber.primaryAttack(dummy, target); // start charge
         assertTrue(saber.canAttack());
-        saber.primaryAttack(dummy, new Vector2D());
+        try { Thread.sleep(50); } catch (InterruptedException e) {}
+        saber.primaryAttack(dummy, target); // release
         assertFalse(saber.canAttack());
+        assertTrue(dummy.getX() > 50);
+    }
+
+    @Test
+    public void blockingTogglesState() {
+        Player dummy = new Player(1, "tester");
+        WeaponStats stats = new WeaponStats(1, 1, 0.1);
+        Lightsaber saber = new Lightsaber(LightsaberCrystal.BLUE, 1.0, stats);
+
+        assertFalse(saber.isBlocking());
+        saber.secondaryAttack(dummy);
+        assertTrue(saber.isBlocking());
+        saber.secondaryAttack(dummy);
+        assertFalse(saber.isBlocking());
     }
 }


### PR DESCRIPTION
## Summary
- implement charge-based lunge in `Lightsaber.primaryAttack`
- toggle and reflect projectiles when blocking in `Lightsaber.secondaryAttack`
- extend lightsaber unit tests for new behaviour

## Testing
- `./run_all_tests.sh`

------
https://chatgpt.com/codex/tasks/task_e_68457ec6c0b08331863ada730bf7f08d