### PR TITLE
Implement lethal lightsaber strikes and new cooldown

### DIFF
--- a/client/app/src/main/java/com/tavuc/weapons/Lightsaber.java
+++ b/client/app/src/main/java/com/tavuc/weapons/Lightsaber.java
@@ -52,7 +52,20 @@ public class Lightsaber extends Weapon {
 
         sounds.play("lightsaber_swing");
         effects.spawn("blade_trail");
+
+        // Check for a hit and apply lethal damage to any target in range
+        if (Client.worldManager != null) {
+            for (Player p : Client.worldManager.getOtherPlayers()) {
+                double dx = p.getX() - wielder.getX();
+                double dy = p.getY() - wielder.getY();
+                if (Math.hypot(dx, dy) <= stats.getRange()) {
+                    p.setHealth(0);
+                }
+            }
+        }
+
         cooldowns.setCooldown("primary", (long) (stats.getCooldown() * 1000));
+        cooldowns.setCooldown("post_swing", 500);
         cycleSwing();
         isCharging = false;
     }
@@ -82,7 +95,9 @@ public class Lightsaber extends Weapon {
 
     @Override
     public boolean canAttack() {
-        return !cooldowns.isOnCooldown("primary") && !isBlocking;
+        return !cooldowns.isOnCooldown("primary") &&
+               !cooldowns.isOnCooldown("post_swing") &&
+               !isBlocking;
     }
 
     public boolean isBlocking() {

--- a/client/app/src/test/java/com/tavuc/weapons/LightsaberTest.java
+++ b/client/app/src/test/java/com/tavuc/weapons/LightsaberTest.java
@@ -2,6 +2,9 @@ package com.tavuc.weapons;
 
 import com.tavuc.models.entities.Player;
 import com.tavuc.utils.Vector2D;
+import com.tavuc.managers.WorldManager;
+import com.tavuc.Client;
+import com.tavuc.networking.models.PlayerJoinedBroadcast;
 import org.junit.Test;
 import static org.junit.Assert.*;
 
@@ -37,5 +40,45 @@ public class LightsaberTest {
         assertTrue(saber.isBlocking());
         saber.secondaryAttack(dummy);
         assertFalse(saber.isBlocking());
+    }
+
+    @Test
+    public void lethalDamageOnHit() {
+        Player attacker = new Player(1, "attacker");
+        WeaponStats stats = new WeaponStats(1, 2, 0.1);
+        Lightsaber saber = new Lightsaber(LightsaberCrystal.BLUE, 1.0, stats);
+
+        // Setup world manager with a single target close to the attacker
+        WorldManager wm = new WorldManager(0);
+        Client.worldManager = wm;
+        PlayerJoinedBroadcast ev = new PlayerJoinedBroadcast("2", "victim",
+                attacker.getX() + 1, attacker.getY(), 0, 0, 0);
+        wm.addPlayer(ev);
+        Player victim = wm.getOtherPlayer(2);
+
+        Vector2D targetPos = new Vector2D(victim.getX(), victim.getY());
+
+        saber.primaryAttack(attacker, targetPos); // start charge
+        saber.primaryAttack(attacker, targetPos); // release
+
+        assertEquals(0, victim.getHealth());
+    }
+
+    @Test
+    public void postSwingCooldownPreventsAttack() {
+        Player attacker = new Player(1, "attacker");
+        WeaponStats stats = new WeaponStats(1, 1, 0.1);
+        Lightsaber saber = new Lightsaber(LightsaberCrystal.BLUE, 1.0, stats);
+
+        Vector2D target = new Vector2D(attacker.getX() + 5, attacker.getY());
+
+        saber.primaryAttack(attacker, target); // start charge
+        saber.primaryAttack(attacker, target); // release
+        assertFalse(saber.canAttack());
+
+        try { Thread.sleep(300); } catch (InterruptedException e) {}
+        assertFalse("Should still be on post-swing cooldown", saber.canAttack());
+        try { Thread.sleep(300); } catch (InterruptedException e) {}
+        assertTrue(saber.canAttack());
     }
 }


### PR DESCRIPTION
## Summary
- add lethal hit logic and post-swing cooldown to `Lightsaber`
- extend `canAttack` to include the new cooldown
- test lethal hits and cooldown behaviour

## Testing
- `./run_all_tests.sh`

------
https://chatgpt.com/codex/tasks/task_e_684581094adc8331b475cf09fbe86271