### PR TITLE
Add Force choke targeting ability

### DIFF
--- a/client/app/src/main/java/com/tavuc/managers/InputManager.java
+++ b/client/app/src/main/java/com/tavuc/managers/InputManager.java
@@ -37,6 +37,7 @@ public class InputManager implements KeyListener {
     private ControlTargetType controlTargetType;
     private Player player;
     private Ship ship;
+    private com.tavuc.weapons.ForcePowers forcePowers;
     private boolean upPressed, downPressed, leftPressed, rightPressed;
     private boolean shiftPressed;
 
@@ -67,6 +68,10 @@ public class InputManager implements KeyListener {
 
     public void setShipTarget(Ship ship) {
         this.ship = ship;
+    }
+
+    public void setForcePowers(com.tavuc.weapons.ForcePowers powers) {
+        this.forcePowers = powers;
     }
 
     /** Enable or disable tile-based movement mode. */
@@ -126,6 +131,9 @@ public class InputManager implements KeyListener {
             if (keyCode == KeyEvent.VK_D || keyCode == KeyEvent.VK_RIGHT) {
                 rightPressed = true;
                 inputBuffer.registerInput(KeyBinding.MOVE_RIGHT);
+            }
+            if (keyCode == KeyEvent.VK_TAB && forcePowers != null) {
+                forcePowers.cycleTarget(player);
             }
             if (keyCode == KeyEvent.VK_SHIFT) {
                 shiftPressed = true;


### PR DESCRIPTION
## Summary
- extend `InputManager` with a reference to `ForcePowers`
- add cycling to the next valid target when TAB is pressed
- implement targeting logic and FORCE_CHOKE ability in `ForcePowers`

## Testing
- `./run_all_tests.sh`

------
https://chatgpt.com/codex/tasks/task_e_68458935cadc8331885adc29c3b52246