### PR TITLE
Add force ability networking

### DIFF
--- a/client/app/src/main/java/com/tavuc/Client.java
+++ b/client/app/src/main/java/com/tavuc/Client.java
@@ -24,6 +24,7 @@ import com.tavuc.networking.models.EntityRemovedBroadcast;
 import com.tavuc.networking.models.ErrorMessage;
 import com.tavuc.networking.models.FireRequest;
 import com.tavuc.networking.models.PlayerAttackRequest;
+import com.tavuc.networking.models.ForceAbilityRequest;
 import com.tavuc.networking.models.GetPlayersRequest;
 import com.tavuc.networking.models.GetPlayersResponse;
 import com.tavuc.networking.models.JoinGameRequest;
@@ -467,6 +468,22 @@ public class Client {
                 String.valueOf(attackerId),
                 String.valueOf(targetId),
                 0.0
+        );
+        out.println(gson.toJson(req));
+    }
+
+    /**
+     * Sends a force ability request to the server.
+     */
+    public static void sendForceAbility(int attackerId, int targetId, String ability) {
+        if (out == null) {
+            System.err.println("Client not connected, cannot send ability request.");
+            return;
+        }
+        ForceAbilityRequest req = new ForceAbilityRequest(
+                String.valueOf(attackerId),
+                String.valueOf(targetId),
+                ability
         );
         out.println(gson.toJson(req));
     }

--- a/client/app/src/main/java/com/tavuc/networking/models/ForceAbilityRequest.java
+++ b/client/app/src/main/java/com/tavuc/networking/models/ForceAbilityRequest.java
@@ -1,0 +1,18 @@
+package com.tavuc.networking.models;
+
+public class ForceAbilityRequest extends BaseMessage {
+    public String attackerId;
+    public String targetId;
+    public String ability;
+
+    public ForceAbilityRequest() {
+        this.type = "FORCE_ABILITY_REQUEST";
+    }
+
+    public ForceAbilityRequest(String attackerId, String targetId, String ability) {
+        this();
+        this.attackerId = attackerId;
+        this.targetId = targetId;
+        this.ability = ability;
+    }
+}

--- a/client/app/src/main/java/com/tavuc/weapons/ForcePowers.java
+++ b/client/app/src/main/java/com/tavuc/weapons/ForcePowers.java
@@ -87,7 +87,7 @@ public class ForcePowers extends Weapon {
             double dx = currentTarget.getX() - wielder.getX();
             double dy = currentTarget.getY() - wielder.getY();
             if (Math.hypot(dx, dy) > stats.getRange()) return;
-            currentTarget.takeDamage((int) stats.getDamage());
+            Client.sendForceAbility(wielder.getPlayerId(), currentTarget.getPlayerId(), ability.name());
         }
 
         sounds.play("force_use");

--- a/server/app/src/main/java/com/tavuc/networking/ClientSession.java
+++ b/server/app/src/main/java/com/tavuc/networking/ClientSession.java
@@ -149,6 +149,9 @@ public class ClientSession implements Runnable {
                 case "PLAYER_ATTACK_REQUEST":
                     handlePlayerAttackRequest(jsonMessage);
                     break;
+                case "FORCE_ABILITY_REQUEST":
+                    handleForceAbilityRequest(jsonMessage);
+                    break;
                 case "FIRE_REQUEST":
                     handleFireRequest(jsonMessage);
                     break;
@@ -347,6 +350,24 @@ public class ClientSession implements Runnable {
         try {
             int targetId = Integer.parseInt(req.targetId);
             currentGameService.handlePlayerAttack(player.getId(), targetId);
+        } catch (NumberFormatException e) {
+            sendMessage(gson.toJson(new ErrorMessage("Invalid target ID.")));
+        }
+    }
+
+    private void handleForceAbilityRequest(String jsonMessage) {
+        ForceAbilityRequest req = gson.fromJson(jsonMessage, ForceAbilityRequest.class);
+        if (currentGameService == null) {
+            sendMessage(gson.toJson(new ErrorMessage("Not in a game.")));
+            return;
+        }
+        if (player == null || !String.valueOf(player.getId()).equals(req.attackerId)) {
+            sendMessage(gson.toJson(new ErrorMessage("Attacker ID mismatch or not authenticated.")));
+            return;
+        }
+        try {
+            int targetId = Integer.parseInt(req.targetId);
+            currentGameService.handleForceAbility(player.getId(), targetId, req.ability);
         } catch (NumberFormatException e) {
             sendMessage(gson.toJson(new ErrorMessage("Invalid target ID.")));
         }

--- a/server/app/src/main/java/com/tavuc/networking/models/ForceAbilityRequest.java
+++ b/server/app/src/main/java/com/tavuc/networking/models/ForceAbilityRequest.java
@@ -1,0 +1,18 @@
+package com.tavuc.networking.models;
+
+public class ForceAbilityRequest extends BaseMessage {
+    public String attackerId;
+    public String targetId;
+    public String ability;
+
+    public ForceAbilityRequest() {
+        this.type = "FORCE_ABILITY_REQUEST";
+    }
+
+    public ForceAbilityRequest(String attackerId, String targetId, String ability) {
+        this();
+        this.attackerId = attackerId;
+        this.targetId = targetId;
+        this.ability = ability;
+    }
+}


### PR DESCRIPTION
## Summary
- add `ForceAbilityRequest` message on client and server
- validate ability effects server-side via new `handleForceAbility`
- send ability requests from the client and forward them in `ClientSession`
- update `ForcePowers` to send requests instead of applying damage locally

## Testing
- `./run_all_tests.sh`

------
https://chatgpt.com/codex/tasks/task_e_68458ab002548331b7664e05ee26f12f