### PR TITLE
Implement enemy AI foundations

### DIFF
--- a/client/app/src/main/java/com/tavuc/ai/AIDirector.java
+++ b/client/app/src/main/java/com/tavuc/ai/AIDirector.java
@@ -1,0 +1,27 @@
+package com.tavuc.ai;
+
+/**
+ * Coordinates high level AI features such as dynamic difficulty.
+ */
+public class AIDirector {
+    private int playerKills;
+    private int playerDeaths;
+    private double difficultyMultiplier = 1.0;
+
+    /** Records a player kill for difficulty analysis. */
+    public void recordKill() { playerKills++; }
+
+    /** Records a player death for difficulty analysis. */
+    public void recordDeath() { playerDeaths++; }
+
+    /**
+     * Simple dynamic difficulty calculation adjusting multiplier between 0.5
+     * and 2 based on kill/death ratio.
+     */
+    public void updateDifficulty() {
+        double ratio = playerDeaths == 0 ? playerKills : (double) playerKills / playerDeaths;
+        difficultyMultiplier = Math.max(0.5, Math.min(2.0, 1.0 + (ratio - 1) * 0.5));
+    }
+
+    public double getDifficultyMultiplier() { return difficultyMultiplier; }
+}

--- a/client/app/src/main/java/com/tavuc/ai/AIState.java
+++ b/client/app/src/main/java/com/tavuc/ai/AIState.java
@@ -1,0 +1,17 @@
+package com.tavuc.ai;
+
+/**
+ * Possible states for an enemy AI.
+ */
+public enum AIState {
+    SPAWNING,
+    PATROLLING,
+    SEARCHING,
+    PURSUING,
+    ATTACKING,
+    RETREATING,
+    FLANKING,
+    TAKING_COVER,
+    STUNNED,
+    DYING
+}

--- a/client/app/src/main/java/com/tavuc/ai/AIStateMachine.java
+++ b/client/app/src/main/java/com/tavuc/ai/AIStateMachine.java
@@ -1,0 +1,37 @@
+package com.tavuc.ai;
+
+import java.util.ArrayList;
+import java.util.EnumMap;
+import java.util.List;
+import java.util.Map;
+
+/**
+ * Simple finite state machine for enemy AI.
+ */
+public class AIStateMachine {
+    private AIState currentState = AIState.SPAWNING;
+    private final Map<AIState, List<StateTransition>> transitions = new EnumMap<>(AIState.class);
+
+    public AIState getCurrentState() {
+        return currentState;
+    }
+
+    public void setCurrentState(AIState state) {
+        this.currentState = state;
+    }
+
+    public void addTransition(AIState from, StateTransition transition) {
+        transitions.computeIfAbsent(from, k -> new ArrayList<>()).add(transition);
+    }
+
+    public void update() {
+        List<StateTransition> ts = transitions.get(currentState);
+        if (ts == null) return;
+        for (StateTransition t : ts) {
+            if (t.shouldTransition()) {
+                currentState = t.getNextState();
+                break;
+            }
+        }
+    }
+}

--- a/client/app/src/main/java/com/tavuc/ai/BasicCombatBehavior.java
+++ b/client/app/src/main/java/com/tavuc/ai/BasicCombatBehavior.java
@@ -1,0 +1,29 @@
+package com.tavuc.ai;
+
+import com.tavuc.models.entities.Entity;
+
+/**
+ * Simple combat behavior that damages the target if within range.
+ */
+public class BasicCombatBehavior implements CombatBehavior {
+
+    private final Entity attacker;
+    private final int damage;
+    private final double range;
+
+    public BasicCombatBehavior(Entity attacker, int damage, double range) {
+        this.attacker = attacker;
+        this.damage = damage;
+        this.range = range;
+    }
+
+    @Override
+    public void performAttack(Entity target) {
+        if (target == null) return;
+        double dx = target.getX() - attacker.getX();
+        double dy = target.getY() - attacker.getY();
+        if (Math.hypot(dx, dy) <= range) {
+            target.takeDamage(damage);
+        }
+    }
+}

--- a/client/app/src/main/java/com/tavuc/ai/BasicPathfindingAgent.java
+++ b/client/app/src/main/java/com/tavuc/ai/BasicPathfindingAgent.java
@@ -1,0 +1,71 @@
+package com.tavuc.ai;
+
+import com.tavuc.managers.WorldManager;
+import com.tavuc.models.planets.Tile;
+import com.tavuc.utils.Vector2D;
+
+import java.util.*;
+
+/**
+ * Simple A* pathfinding agent operating on the world's tile grid.
+ */
+public class BasicPathfindingAgent implements PathfindingAgent {
+
+    private final WorldManager world;
+
+    public BasicPathfindingAgent(WorldManager world) {
+        this.world = world;
+    }
+
+    private static class Node implements Comparable<Node> {
+        int x, y; double g, f; Node parent;
+        Node(int x, int y, double g, double f, Node parent) {
+            this.x=x; this.y=y; this.g=g; this.f=f; this.parent=parent;
+        }
+        @Override
+        public int compareTo(Node o) { return Double.compare(this.f, o.f); }
+    }
+
+    private boolean isBlocked(int x, int y) {
+        Tile tile = world.getTileAt(x, y);
+        return tile != null && tile.isSolid();
+    }
+
+    private List<Vector2D> computePath(int startX, int startY, int targetX, int targetY) {
+        PriorityQueue<Node> open = new PriorityQueue<>();
+        Map<String, Node> visited = new HashMap<>();
+        Node start = new Node(startX, startY,0,0,null);
+        open.add(start);
+        int[] dirs = {1,0,-1,0,0,1,0,-1};
+        while(!open.isEmpty()) {
+            Node n = open.poll();
+            String key = n.x+","+n.y;
+            if(visited.containsKey(key)) continue;
+            visited.put(key,n);
+            if(n.x==targetX && n.y==targetY) {
+                List<Vector2D> path = new ArrayList<>();
+                while(n.parent!=null){ path.add(0,new Vector2D(n.x,n.y)); n=n.parent; }
+                return path;
+            }
+            for(int i=0;i<dirs.length;i+=2) {
+                int nx=n.x+dirs[i]; int ny=n.y+dirs[i+1];
+                if(isBlocked(nx,ny)) continue;
+                double ng=n.g+1;
+                double h=Math.abs(nx-targetX)+Math.abs(ny-targetY);
+                Node nn = new Node(nx,ny,ng,ng+h,n);
+                open.add(nn);
+            }
+        }
+        return Collections.emptyList();
+    }
+
+    @Override
+    public Vector2D getNextMove(Vector2D start, Vector2D target) {
+        List<Vector2D> path = computePath((int)start.getX(),(int)start.getY(),(int)target.getX(),(int)target.getY());
+        if(path.isEmpty()) return new Vector2D();
+        Vector2D next = path.get(0);
+        Vector2D dir = new Vector2D(next.getX()-start.getX(), next.getY()-start.getY());
+        dir.normalize();
+        return dir;
+    }
+}

--- a/client/app/src/main/java/com/tavuc/ai/BasicTargetingSystem.java
+++ b/client/app/src/main/java/com/tavuc/ai/BasicTargetingSystem.java
@@ -1,0 +1,34 @@
+package com.tavuc.ai;
+
+import com.tavuc.managers.WorldManager;
+import com.tavuc.models.entities.Entity;
+import com.tavuc.models.entities.Player;
+
+import java.util.List;
+
+/**
+ * Targets the closest player from the world manager's list.
+ */
+public class BasicTargetingSystem implements TargetingSystem {
+    private final WorldManager world;
+    private final Entity self;
+
+    public BasicTargetingSystem(WorldManager world, Entity self) {
+        this.world = world;
+        this.self = self;
+    }
+
+    @Override
+    public Entity acquireTarget() {
+        List<Player> players = world.getOtherPlayers();
+        Entity closest = null;
+        double best = Double.MAX_VALUE;
+        for (Player p : players) {
+            double dx = p.getX() - self.getX();
+            double dy = p.getY() - self.getY();
+            double dist = dx*dx + dy*dy;
+            if (dist < best) { best = dist; closest = p; }
+        }
+        return closest;
+    }
+}

--- a/client/app/src/main/java/com/tavuc/ai/CombatBehavior.java
+++ b/client/app/src/main/java/com/tavuc/ai/CombatBehavior.java
@@ -1,0 +1,13 @@
+package com.tavuc.ai;
+
+import com.tavuc.models.entities.Entity;
+
+/**
+ * Encapsulates how an enemy fights.
+ */
+public interface CombatBehavior {
+    /**
+     * Perform an attack against the given target.
+     */
+    void performAttack(Entity target);
+}

--- a/client/app/src/main/java/com/tavuc/ai/DifficultyScaling.java
+++ b/client/app/src/main/java/com/tavuc/ai/DifficultyScaling.java
@@ -1,0 +1,16 @@
+package com.tavuc.ai;
+
+/**
+ * Placeholder for difficulty scaling settings.
+ */
+public class DifficultyScaling {
+    private double multiplier = 1.0;
+
+    public double getMultiplier() {
+        return multiplier;
+    }
+
+    public void setMultiplier(double multiplier) {
+        this.multiplier = multiplier;
+    }
+}

--- a/client/app/src/main/java/com/tavuc/ai/EnemySpawnData.java
+++ b/client/app/src/main/java/com/tavuc/ai/EnemySpawnData.java
@@ -1,0 +1,6 @@
+package com.tavuc.ai;
+
+import com.tavuc.models.entities.enemies.EnemyType;
+
+/** Data describing enemies to spawn in a wave. */
+public record EnemySpawnData(EnemyType type, int count) {}

--- a/client/app/src/main/java/com/tavuc/ai/PathfindingAgent.java
+++ b/client/app/src/main/java/com/tavuc/ai/PathfindingAgent.java
@@ -1,0 +1,18 @@
+package com.tavuc.ai;
+
+import com.tavuc.utils.Vector2D;
+
+/**
+ * Basic interface for AI pathfinding.
+ */
+public interface PathfindingAgent {
+    /**
+     * Calculates the next movement step for an entity moving from the
+     * given start position toward the given target.
+     *
+     * @param start  current location of the entity
+     * @param target desired target location
+     * @return direction vector for the next movement step
+     */
+    Vector2D getNextMove(Vector2D start, Vector2D target);
+}

--- a/client/app/src/main/java/com/tavuc/ai/SpawnPattern.java
+++ b/client/app/src/main/java/com/tavuc/ai/SpawnPattern.java
@@ -1,0 +1,11 @@
+package com.tavuc.ai;
+
+/**
+ * Patterns for spawning enemies.
+ */
+public enum SpawnPattern {
+    PERIMETER,
+    DROP_POD,
+    TELEPORT,
+    REINFORCEMENT
+}

--- a/client/app/src/main/java/com/tavuc/ai/StateTransition.java
+++ b/client/app/src/main/java/com/tavuc/ai/StateTransition.java
@@ -1,0 +1,24 @@
+package com.tavuc.ai;
+
+import java.util.function.Supplier;
+
+/**
+ * Describes a possible transition between AI states.
+ */
+public class StateTransition {
+    private final AIState nextState;
+    private final Supplier<Boolean> condition;
+
+    public StateTransition(AIState nextState, Supplier<Boolean> condition) {
+        this.nextState = nextState;
+        this.condition = condition;
+    }
+
+    public AIState getNextState() {
+        return nextState;
+    }
+
+    public boolean shouldTransition() {
+        return condition.get();
+    }
+}

--- a/client/app/src/main/java/com/tavuc/ai/TargetingSystem.java
+++ b/client/app/src/main/java/com/tavuc/ai/TargetingSystem.java
@@ -1,0 +1,10 @@
+package com.tavuc.ai;
+
+import com.tavuc.models.entities.Entity;
+
+/**
+ * Picks a target for an enemy.
+ */
+public interface TargetingSystem {
+    Entity acquireTarget();
+}

--- a/client/app/src/main/java/com/tavuc/ai/WaveConfiguration.java
+++ b/client/app/src/main/java/com/tavuc/ai/WaveConfiguration.java
@@ -1,0 +1,47 @@
+package com.tavuc.ai;
+
+import java.time.Duration;
+import java.util.List;
+
+/**
+ * Configuration for a single wave of enemies.
+ */
+public class WaveConfiguration {
+    private int waveNumber;
+    private List<EnemySpawnData> enemies;
+    private SpawnPattern spawnPattern;
+    private Object events;
+    private Duration timeLimit;
+
+    public int getWaveNumber() {
+        return waveNumber;
+    }
+
+    public void setWaveNumber(int waveNumber) {
+        this.waveNumber = waveNumber;
+    }
+
+    public List<EnemySpawnData> getEnemies() {
+        return enemies;
+    }
+
+    public void setEnemies(List<EnemySpawnData> enemies) {
+        this.enemies = enemies;
+    }
+
+    public SpawnPattern getSpawnPattern() {
+        return spawnPattern;
+    }
+
+    public void setSpawnPattern(SpawnPattern spawnPattern) {
+        this.spawnPattern = spawnPattern;
+    }
+
+    public Duration getTimeLimit() {
+        return timeLimit;
+    }
+
+    public void setTimeLimit(Duration timeLimit) {
+        this.timeLimit = timeLimit;
+    }
+}

--- a/client/app/src/main/java/com/tavuc/ai/WaveManager.java
+++ b/client/app/src/main/java/com/tavuc/ai/WaveManager.java
@@ -1,0 +1,45 @@
+package com.tavuc.ai;
+
+import com.tavuc.managers.WorldManager;
+import com.tavuc.models.entities.enemies.*;
+import java.util.*;
+
+/**
+ * Manages spawning waves of enemies.
+ */
+public class WaveManager {
+    private WaveConfiguration currentWave;
+    private List<WaveConfiguration> waves = new ArrayList<>();
+    private int index = 0;
+
+    public void setWaves(List<WaveConfiguration> waves) {
+        this.waves = waves;
+        this.index = 0;
+    }
+
+    public List<Enemy> spawnNextWave(WorldManager world) {
+        if (index >= waves.size()) return Collections.emptyList();
+        currentWave = waves.get(index++);
+        List<Enemy> spawned = new ArrayList<>();
+        for (EnemySpawnData data : currentWave.getEnemies()) {
+            for (int i = 0; i < data.count(); i++) {
+                double x = 50 + i*5;
+                double y = 50 + i*5;
+                if (data.type() == EnemyType.TROOPER) {
+                    spawned.add(new BasicTrooper(x, y, world, TrooperWeapon.BLASTER));
+                } else if (data.type() == EnemyType.MECH) {
+                    spawned.add(new BasicMech(x, y, world));
+                }
+            }
+        }
+        return spawned;
+    }
+
+    public WaveConfiguration getCurrentWave() {
+        return currentWave;
+    }
+
+    public void setCurrentWave(WaveConfiguration wave) {
+        this.currentWave = wave;
+    }
+}

--- a/client/app/src/main/java/com/tavuc/models/entities/enemies/BasicMech.java
+++ b/client/app/src/main/java/com/tavuc/models/entities/enemies/BasicMech.java
@@ -1,0 +1,46 @@
+package com.tavuc.models.entities.enemies;
+
+import com.tavuc.ai.*;
+import com.tavuc.managers.WorldManager;
+import com.tavuc.utils.Vector2D;
+import com.tavuc.models.entities.Entity;
+
+import java.awt.Graphics2D;
+
+/**
+ * Simple mech enemy with melee attack.
+ */
+public class BasicMech extends Mech {
+
+    private final WorldManager world;
+    private Entity target;
+
+    public BasicMech(double x, double y, WorldManager world) {
+        super(x, y, 30, 30, 1.5, 10);
+        this.world = world;
+        this.pathfinding = new BasicPathfindingAgent(world);
+        this.targeting = new BasicTargetingSystem(world, this);
+        this.combatBehavior = new BasicCombatBehavior(this,2, 25);
+    }
+
+    @Override
+    public void update() {
+        if (target == null || !target.isAlive()) {
+            target = targeting.acquireTarget();
+        }
+        if (target != null) {
+            Vector2D next = pathfinding.getNextMove(new Vector2D(getX(), getY()), new Vector2D(target.getX(), target.getY()));
+            setDx(next.getX() * getVelocity());
+            setDy(next.getY() * getVelocity());
+            move();
+            if (Math.hypot(target.getX()-getX(), target.getY()-getY()) <= 25) {
+                combatBehavior.performAttack(target);
+            }
+        }
+    }
+
+    @Override
+    public void draw(Graphics2D g2d, double offsetX, double offsetY) {
+        g2d.fillOval((int)(getX()-offsetX),(int)(getY()-offsetY),30,30);
+    }
+}

--- a/client/app/src/main/java/com/tavuc/models/entities/enemies/BasicTrooper.java
+++ b/client/app/src/main/java/com/tavuc/models/entities/enemies/BasicTrooper.java
@@ -1,0 +1,46 @@
+package com.tavuc.models.entities.enemies;
+
+import com.tavuc.ai.*;
+import com.tavuc.managers.WorldManager;
+import com.tavuc.utils.Vector2D;
+import com.tavuc.models.entities.Entity;
+
+import java.awt.Graphics2D;
+
+/**
+ * Basic AI driven trooper used for tests.
+ */
+public class BasicTrooper extends Trooper {
+
+    private final WorldManager world;
+    private Entity target;
+
+    public BasicTrooper(double x, double y, WorldManager world, TrooperWeapon weapon) {
+        super(x, y, 20, 20, 2.0, 5, weapon);
+        this.world = world;
+        this.pathfinding = new BasicPathfindingAgent(world);
+        this.targeting = new BasicTargetingSystem(world, this);
+        this.combatBehavior = new BasicCombatBehavior(this,1, weapon.getRange());
+    }
+
+    @Override
+    public void update() {
+        if (target == null || !target.isAlive()) {
+            target = targeting.acquireTarget();
+        }
+        if (target != null) {
+            Vector2D next = pathfinding.getNextMove(new Vector2D(getX(), getY()), new Vector2D(target.getX(), target.getY()));
+            setDx(next.getX() * getVelocity());
+            setDy(next.getY() * getVelocity());
+            move();
+            if (Math.hypot(target.getX()-getX(), target.getY()-getY()) <= getWeapon().getRange()) {
+                combatBehavior.performAttack(target);
+            }
+        }
+    }
+
+    @Override
+    public void draw(Graphics2D g2d, double offsetX, double offsetY) {
+        g2d.fillRect((int)(getX()-offsetX),(int)(getY()-offsetY),20,20);
+    }
+}

--- a/client/app/src/main/java/com/tavuc/models/entities/enemies/Enemy.java
+++ b/client/app/src/main/java/com/tavuc/models/entities/enemies/Enemy.java
@@ -1,0 +1,31 @@
+package com.tavuc.models.entities.enemies;
+
+import com.tavuc.ai.AIStateMachine;
+import com.tavuc.ai.PathfindingAgent;
+import com.tavuc.ai.TargetingSystem;
+import com.tavuc.ai.CombatBehavior;
+import com.tavuc.ai.DifficultyScaling;
+import com.tavuc.models.entities.Entity;
+
+/**
+ * Base class for all enemy entities.
+ */
+public abstract class Enemy extends Entity {
+    protected AIStateMachine stateMachine;
+    protected PathfindingAgent pathfinding;
+    protected TargetingSystem targeting;
+    protected CombatBehavior combatBehavior;
+    protected EnemyType type;
+    protected DifficultyScaling scaling;
+
+    public Enemy(double x, double y, int width, int height, double velocity, int maxHealth, EnemyType type) {
+        super(x, y, width, height, velocity, maxHealth);
+        this.type = type;
+        this.stateMachine = new AIStateMachine();
+        this.scaling = new DifficultyScaling();
+    }
+
+    public AIStateMachine getStateMachine() {
+        return stateMachine;
+    }
+}

--- a/client/app/src/main/java/com/tavuc/models/entities/enemies/EnemyType.java
+++ b/client/app/src/main/java/com/tavuc/models/entities/enemies/EnemyType.java
@@ -1,0 +1,9 @@
+package com.tavuc.models.entities.enemies;
+
+/**
+ * Different enemy categories.
+ */
+public enum EnemyType {
+    TROOPER,
+    MECH
+}

--- a/client/app/src/main/java/com/tavuc/models/entities/enemies/Mech.java
+++ b/client/app/src/main/java/com/tavuc/models/entities/enemies/Mech.java
@@ -1,0 +1,15 @@
+package com.tavuc.models.entities.enemies;
+
+/**
+ * Heavy mech enemy.
+ */
+public abstract class Mech extends Enemy {
+    private Object charge;
+    private Object combos;
+    private Object armor;
+    private Object weakPoints;
+
+    public Mech(double x, double y, int width, int height, double velocity, int maxHealth) {
+        super(x, y, width, height, velocity, maxHealth, EnemyType.MECH);
+    }
+}

--- a/client/app/src/main/java/com/tavuc/models/entities/enemies/Trooper.java
+++ b/client/app/src/main/java/com/tavuc/models/entities/enemies/Trooper.java
@@ -1,0 +1,25 @@
+package com.tavuc.models.entities.enemies;
+
+import com.tavuc.ai.AIStateMachine;
+import com.tavuc.ai.CombatBehavior;
+import com.tavuc.ai.PathfindingAgent;
+import com.tavuc.ai.TargetingSystem;
+
+/**
+ * Basic trooper enemy implementation.
+ */
+public abstract class Trooper extends Enemy {
+    private TrooperWeapon weapon;
+    private Object coverSystem; // placeholder for a cover system
+    private Object formation;   // placeholder for formation controller
+    private Object suppression; // placeholder for suppression behavior
+
+    public Trooper(double x, double y, int width, int height, double velocity, int maxHealth, TrooperWeapon weapon) {
+        super(x, y, width, height, velocity, maxHealth, EnemyType.TROOPER);
+        this.weapon = weapon;
+    }
+
+    public TrooperWeapon getWeapon() {
+        return weapon;
+    }
+}

--- a/client/app/src/main/java/com/tavuc/models/entities/enemies/TrooperWeapon.java
+++ b/client/app/src/main/java/com/tavuc/models/entities/enemies/TrooperWeapon.java
@@ -1,0 +1,34 @@
+package com.tavuc.models.entities.enemies;
+
+import com.tavuc.weapons.ProjectileType;
+
+/**
+ * Weapon types for troopers.
+ */
+public enum TrooperWeapon {
+    BLASTER(300, 2.0, ProjectileType.ENERGY),
+    LAUNCHER(450, 4.0, ProjectileType.EXPLOSIVE),
+    RIFLE(500, 1.5, ProjectileType.KINETIC);
+
+    private final int range;
+    private final double cooldown;
+    private final ProjectileType projectileType;
+
+    TrooperWeapon(int range, double cooldown, ProjectileType type) {
+        this.range = range;
+        this.cooldown = cooldown;
+        this.projectileType = type;
+    }
+
+    public int getRange() {
+        return range;
+    }
+
+    public double getCooldown() {
+        return cooldown;
+    }
+
+    public ProjectileType getProjectileType() {
+        return projectileType;
+    }
+}

--- a/client/app/src/main/java/com/tavuc/weapons/ProjectileType.java
+++ b/client/app/src/main/java/com/tavuc/weapons/ProjectileType.java
@@ -5,5 +5,8 @@ package com.tavuc.weapons;
  */
 public enum ProjectileType {
     STANDARD,
-    CHARGED
+    CHARGED,
+    ENERGY,
+    EXPLOSIVE,
+    KINETIC
 }

--- a/client/app/src/test/java/com/tavuc/ai/AIDirectorTest.java
+++ b/client/app/src/test/java/com/tavuc/ai/AIDirectorTest.java
@@ -1,0 +1,15 @@
+package com.tavuc.ai;
+
+import org.junit.Test;
+import static org.junit.Assert.*;
+
+public class AIDirectorTest {
+    @Test
+    public void difficultyAdjustsWithKills() {
+        AIDirector director = new AIDirector();
+        director.recordKill();
+        director.recordKill();
+        director.updateDifficulty();
+        assertTrue(director.getDifficultyMultiplier() > 1.0);
+    }
+}

--- a/client/app/src/test/java/com/tavuc/ai/BasicPathfindingAgentTest.java
+++ b/client/app/src/test/java/com/tavuc/ai/BasicPathfindingAgentTest.java
@@ -1,0 +1,17 @@
+package com.tavuc.ai;
+
+import com.tavuc.managers.WorldManager;
+import com.tavuc.utils.Vector2D;
+import org.junit.Test;
+
+import static org.junit.Assert.*;
+
+public class BasicPathfindingAgentTest {
+    @Test
+    public void simpleStraightPath() {
+        WorldManager wm = new WorldManager(0);
+        BasicPathfindingAgent agent = new BasicPathfindingAgent(wm);
+        Vector2D move = agent.getNextMove(new Vector2D(0,0), new Vector2D(4,0));
+        assertTrue(move.getX() > 0);
+    }
+}

--- a/server/app/src/main/java/com/tavuc/ai/AIDirector.java
+++ b/server/app/src/main/java/com/tavuc/ai/AIDirector.java
@@ -1,0 +1,20 @@
+package com.tavuc.ai;
+
+/**
+ * Coordinates high level AI features on the server.
+ */
+public class AIDirector {
+    private int playerKills;
+    private int playerDeaths;
+    private double difficultyMultiplier = 1.0;
+
+    public void recordKill() { playerKills++; }
+    public void recordDeath() { playerDeaths++; }
+
+    public void updateDifficulty() {
+        double ratio = playerDeaths == 0 ? playerKills : (double) playerKills / playerDeaths;
+        difficultyMultiplier = Math.max(0.5, Math.min(2.0, 1.0 + (ratio - 1) * 0.5));
+    }
+
+    public double getDifficultyMultiplier() { return difficultyMultiplier; }
+}

--- a/server/app/src/main/java/com/tavuc/ai/AIState.java
+++ b/server/app/src/main/java/com/tavuc/ai/AIState.java
@@ -1,0 +1,17 @@
+package com.tavuc.ai;
+
+/**
+ * Possible states for an enemy AI on the server side.
+ */
+public enum AIState {
+    SPAWNING,
+    PATROLLING,
+    SEARCHING,
+    PURSUING,
+    ATTACKING,
+    RETREATING,
+    FLANKING,
+    TAKING_COVER,
+    STUNNED,
+    DYING
+}

--- a/server/app/src/main/java/com/tavuc/ai/AIStateMachine.java
+++ b/server/app/src/main/java/com/tavuc/ai/AIStateMachine.java
@@ -1,0 +1,37 @@
+package com.tavuc.ai;
+
+import java.util.ArrayList;
+import java.util.EnumMap;
+import java.util.List;
+import java.util.Map;
+
+/**
+ * Simple finite state machine for enemy AI on the server.
+ */
+public class AIStateMachine {
+    private AIState currentState = AIState.SPAWNING;
+    private final Map<AIState, List<StateTransition>> transitions = new EnumMap<>(AIState.class);
+
+    public AIState getCurrentState() {
+        return currentState;
+    }
+
+    public void setCurrentState(AIState state) {
+        this.currentState = state;
+    }
+
+    public void addTransition(AIState from, StateTransition transition) {
+        transitions.computeIfAbsent(from, k -> new ArrayList<>()).add(transition);
+    }
+
+    public void update() {
+        List<StateTransition> ts = transitions.get(currentState);
+        if (ts == null) return;
+        for (StateTransition t : ts) {
+            if (t.shouldTransition()) {
+                currentState = t.getNextState();
+                break;
+            }
+        }
+    }
+}

--- a/server/app/src/main/java/com/tavuc/ai/BasicCombatBehavior.java
+++ b/server/app/src/main/java/com/tavuc/ai/BasicCombatBehavior.java
@@ -1,0 +1,29 @@
+package com.tavuc.ai;
+
+import com.tavuc.models.entities.Entity;
+
+/**
+ * Basic combat behavior used on the server.
+ */
+public class BasicCombatBehavior implements CombatBehavior {
+
+    private final Entity attacker;
+    private final int damage;
+    private final double range;
+
+    public BasicCombatBehavior(Entity attacker, int damage, double range) {
+        this.attacker = attacker;
+        this.damage = damage;
+        this.range = range;
+    }
+
+    @Override
+    public void performAttack(Entity target) {
+        if (target == null) return;
+        double dx = target.getX() - attacker.getX();
+        double dy = target.getY() - attacker.getY();
+        if (Math.hypot(dx, dy) <= range) {
+            target.takeDamage(damage);
+        }
+    }
+}

--- a/server/app/src/main/java/com/tavuc/ai/BasicPathfindingAgent.java
+++ b/server/app/src/main/java/com/tavuc/ai/BasicPathfindingAgent.java
@@ -1,0 +1,63 @@
+package com.tavuc.ai;
+
+import java.util.*;
+
+/**
+ * Lightweight A* pathfinding agent for the server. It operates on a simple
+ * boolean grid provided at construction where {@code true} indicates a
+ * blocked tile.
+ */
+public class BasicPathfindingAgent implements PathfindingAgent {
+
+    private final boolean[][] blocked;
+
+    public BasicPathfindingAgent(boolean[][] blocked) {
+        this.blocked = blocked;
+    }
+
+    private boolean isBlocked(int x, int y) {
+        if (x < 0 || y < 0 || x >= blocked.length || y >= blocked[0].length) {
+            return true;
+        }
+        return blocked[x][y];
+    }
+
+    private static class Node implements Comparable<Node> {
+        int x, y; double g, f; Node parent;
+        Node(int x,int y,double g,double f,Node p){this.x=x;this.y=y;this.g=g;this.f=f;this.parent=p;}
+        public int compareTo(Node o){return Double.compare(f,o.f);} }
+
+    private List<int[]> computePath(int sx,int sy,int tx,int ty){
+        PriorityQueue<Node> open=new PriorityQueue<>();
+        Map<String,Node> visited=new HashMap<>();
+        open.add(new Node(sx,sy,0,0,null));
+        int[] dirs={1,0,-1,0,0,1,0,-1};
+        while(!open.isEmpty()){
+            Node n=open.poll();
+            String k=n.x+","+n.y; if(visited.containsKey(k)) continue; visited.put(k,n);
+            if(n.x==tx && n.y==ty){
+                List<int[]> path=new ArrayList<>();
+                while(n.parent!=null){path.add(0,new int[]{n.x,n.y}); n=n.parent;}
+                return path; }
+            for(int i=0;i<dirs.length;i+=2){
+                int nx=n.x+dirs[i]; int ny=n.y+dirs[i+1];
+                if(isBlocked(nx,ny)) continue;
+                double ng=n.g+1; double h=Math.abs(nx-tx)+Math.abs(ny-ty);
+                open.add(new Node(nx,ny,ng,ng+h,n));
+            }
+        }
+        return Collections.emptyList();
+    }
+
+    @Override
+    public int[] getNextMove(int startX, int startY, int targetX, int targetY) {
+        List<int[]> path=computePath(startX,startY,targetX,targetY);
+        if(path.isEmpty()) return new int[]{0,0};
+        int[] next=path.get(0);
+        int dx = next[0]-startX;
+        int dy = next[1]-startY;
+        if(dx!=0) dx = dx/Math.abs(dx);
+        if(dy!=0) dy = dy/Math.abs(dy);
+        return new int[]{dx,dy};
+    }
+}

--- a/server/app/src/main/java/com/tavuc/ai/BasicTargetingSystem.java
+++ b/server/app/src/main/java/com/tavuc/ai/BasicTargetingSystem.java
@@ -1,0 +1,23 @@
+package com.tavuc.ai;
+
+import com.tavuc.models.entities.Entity;
+
+import java.util.List;
+
+/**
+ * Very small targeting system used on the server to pick the first
+ * available target from a provided list.
+ */
+public class BasicTargetingSystem implements TargetingSystem {
+
+    private final List<? extends Entity> possibleTargets;
+
+    public BasicTargetingSystem(List<? extends Entity> targets) {
+        this.possibleTargets = targets;
+    }
+
+    @Override
+    public Entity acquireTarget() {
+        return possibleTargets.isEmpty() ? null : possibleTargets.get(0);
+    }
+}

--- a/server/app/src/main/java/com/tavuc/ai/CombatBehavior.java
+++ b/server/app/src/main/java/com/tavuc/ai/CombatBehavior.java
@@ -1,0 +1,13 @@
+package com.tavuc.ai;
+
+import com.tavuc.models.entities.Entity;
+
+/**
+ * Encapsulates how an enemy fights on the server.
+ */
+public interface CombatBehavior {
+    /**
+     * Perform an attack against the given target.
+     */
+    void performAttack(Entity target);
+}

--- a/server/app/src/main/java/com/tavuc/ai/DifficultyScaling.java
+++ b/server/app/src/main/java/com/tavuc/ai/DifficultyScaling.java
@@ -1,0 +1,16 @@
+package com.tavuc.ai;
+
+/**
+ * Placeholder for difficulty scaling settings on the server.
+ */
+public class DifficultyScaling {
+    private double multiplier = 1.0;
+
+    public double getMultiplier() {
+        return multiplier;
+    }
+
+    public void setMultiplier(double multiplier) {
+        this.multiplier = multiplier;
+    }
+}

--- a/server/app/src/main/java/com/tavuc/ai/EnemySpawnData.java
+++ b/server/app/src/main/java/com/tavuc/ai/EnemySpawnData.java
@@ -1,0 +1,6 @@
+package com.tavuc.ai;
+
+import com.tavuc.models.entities.enemies.EnemyType;
+
+/** Data describing enemies to spawn in a wave. */
+public record EnemySpawnData(EnemyType type, int count) {}

--- a/server/app/src/main/java/com/tavuc/ai/PathfindingAgent.java
+++ b/server/app/src/main/java/com/tavuc/ai/PathfindingAgent.java
@@ -1,0 +1,17 @@
+package com.tavuc.ai;
+
+/**
+ * Basic interface for AI pathfinding on the server.
+ */
+public interface PathfindingAgent {
+    /**
+     * Calculates the next movement step for an entity.
+     *
+     * @param startX starting X position
+     * @param startY starting Y position
+     * @param targetX target X position
+     * @param targetY target Y position
+     * @return movement vector of length 2 {dx, dy}
+     */
+    int[] getNextMove(int startX, int startY, int targetX, int targetY);
+}

--- a/server/app/src/main/java/com/tavuc/ai/SpawnPattern.java
+++ b/server/app/src/main/java/com/tavuc/ai/SpawnPattern.java
@@ -1,0 +1,11 @@
+package com.tavuc.ai;
+
+/**
+ * Patterns for spawning enemies on the server.
+ */
+public enum SpawnPattern {
+    PERIMETER,
+    DROP_POD,
+    TELEPORT,
+    REINFORCEMENT
+}

--- a/server/app/src/main/java/com/tavuc/ai/StateTransition.java
+++ b/server/app/src/main/java/com/tavuc/ai/StateTransition.java
@@ -1,0 +1,24 @@
+package com.tavuc.ai;
+
+import java.util.function.Supplier;
+
+/**
+ * Describes a possible transition between AI states on the server.
+ */
+public class StateTransition {
+    private final AIState nextState;
+    private final Supplier<Boolean> condition;
+
+    public StateTransition(AIState nextState, Supplier<Boolean> condition) {
+        this.nextState = nextState;
+        this.condition = condition;
+    }
+
+    public AIState getNextState() {
+        return nextState;
+    }
+
+    public boolean shouldTransition() {
+        return condition.get();
+    }
+}

--- a/server/app/src/main/java/com/tavuc/ai/TargetingSystem.java
+++ b/server/app/src/main/java/com/tavuc/ai/TargetingSystem.java
@@ -1,0 +1,10 @@
+package com.tavuc.ai;
+
+import com.tavuc.models.entities.Entity;
+
+/**
+ * Picks a target for an enemy on the server.
+ */
+public interface TargetingSystem {
+    Entity acquireTarget();
+}

--- a/server/app/src/main/java/com/tavuc/ai/WaveConfiguration.java
+++ b/server/app/src/main/java/com/tavuc/ai/WaveConfiguration.java
@@ -1,0 +1,47 @@
+package com.tavuc.ai;
+
+import java.time.Duration;
+import java.util.List;
+
+/**
+ * Configuration for a single wave of enemies on the server.
+ */
+public class WaveConfiguration {
+    private int waveNumber;
+    private List<EnemySpawnData> enemies;
+    private SpawnPattern spawnPattern;
+    private Object events;
+    private Duration timeLimit;
+
+    public int getWaveNumber() {
+        return waveNumber;
+    }
+
+    public void setWaveNumber(int waveNumber) {
+        this.waveNumber = waveNumber;
+    }
+
+    public List<EnemySpawnData> getEnemies() {
+        return enemies;
+    }
+
+    public void setEnemies(List<EnemySpawnData> enemies) {
+        this.enemies = enemies;
+    }
+
+    public SpawnPattern getSpawnPattern() {
+        return spawnPattern;
+    }
+
+    public void setSpawnPattern(SpawnPattern spawnPattern) {
+        this.spawnPattern = spawnPattern;
+    }
+
+    public Duration getTimeLimit() {
+        return timeLimit;
+    }
+
+    public void setTimeLimit(Duration timeLimit) {
+        this.timeLimit = timeLimit;
+    }
+}

--- a/server/app/src/main/java/com/tavuc/ai/WaveManager.java
+++ b/server/app/src/main/java/com/tavuc/ai/WaveManager.java
@@ -1,0 +1,41 @@
+package com.tavuc.ai;
+
+import com.tavuc.models.entities.enemies.*;
+import com.tavuc.models.entities.Entity;
+import java.util.*;
+
+/**
+ * Manages spawning waves of enemies on the server.
+ */
+public class WaveManager {
+    private WaveConfiguration currentWave;
+    private List<WaveConfiguration> waves = new ArrayList<>();
+    private int index = 0;
+
+    public void setWaves(List<WaveConfiguration> waves) {
+        this.waves = waves;
+        this.index = 0;
+    }
+
+    public List<Enemy> spawnNextWave(boolean[][] blocked, Entity target) {
+        if (index >= waves.size()) return Collections.emptyList();
+        currentWave = waves.get(index++);
+        List<Enemy> spawned = new ArrayList<>();
+        for (EnemySpawnData data : currentWave.getEnemies()) {
+            for (int i = 0; i < data.count(); i++) {
+                int x = 50 + i*5;
+                int y = 50 + i*5;
+                if (data.type() == EnemyType.TROOPER) {
+                    spawned.add(new BasicTrooper(i, "t", x, y, TrooperWeapon.BLASTER, blocked, target));
+                } else if (data.type() == EnemyType.MECH) {
+                    spawned.add(new BasicMech(i, "m", x, y, blocked, target));
+                }
+            }
+        }
+        return spawned;
+    }
+
+    public WaveConfiguration getCurrentWave() {
+        return currentWave;
+    }
+}

--- a/server/app/src/main/java/com/tavuc/models/entities/enemies/BasicMech.java
+++ b/server/app/src/main/java/com/tavuc/models/entities/enemies/BasicMech.java
@@ -1,0 +1,39 @@
+package com.tavuc.models.entities.enemies;
+
+import com.tavuc.ai.*;
+import com.tavuc.models.entities.Entity;
+
+/**
+ * Minimal server side mech.
+ */
+public class BasicMech extends Mech {
+
+    private Entity target;
+    private final PathfindingAgent path;
+    private final TargetingSystem targetingSys;
+    private final CombatBehavior combat;
+
+    public BasicMech(int id, String name, int x, int y, boolean[][] blocked, Entity target) {
+        super(id, name, x, y, 10, 30, 30);
+        this.target = target;
+        this.path = new BasicPathfindingAgent(blocked);
+        this.targetingSys = new BasicTargetingSystem(java.util.List.of(target));
+        this.combat = new BasicCombatBehavior(this,2,25);
+    }
+
+    @Override
+    public void update() {
+        if (target == null || target.getHealth() <= 0) {
+            target = targetingSys.acquireTarget();
+        }
+        if (target != null) {
+            int[] mv = path.getNextMove(getX(), getY(), target.getX(), target.getY());
+            setDx(mv[0]);
+            setDy(mv[1]);
+            super.update();
+            if (Math.hypot(target.getX()-getX(), target.getY()-getY()) <= 25) {
+                combat.performAttack(target);
+            }
+        }
+    }
+}

--- a/server/app/src/main/java/com/tavuc/models/entities/enemies/BasicTrooper.java
+++ b/server/app/src/main/java/com/tavuc/models/entities/enemies/BasicTrooper.java
@@ -1,0 +1,39 @@
+package com.tavuc.models.entities.enemies;
+
+import com.tavuc.ai.*;
+import com.tavuc.models.entities.Entity;
+
+/**
+ * Minimal server side trooper for tests.
+ */
+public class BasicTrooper extends Trooper {
+
+    private Entity target;
+    private final PathfindingAgent path;
+    private final TargetingSystem targetingSys;
+    private final CombatBehavior combat;
+
+    public BasicTrooper(int id, String name, int x, int y, TrooperWeapon weapon, boolean[][] blocked, Entity target) {
+        super(id, name, x, y, 5, 20, 20, weapon);
+        this.target = target;
+        this.path = new BasicPathfindingAgent(blocked);
+        this.targetingSys = new BasicTargetingSystem(java.util.List.of(target));
+        this.combat = new BasicCombatBehavior(this,1,5);
+    }
+
+    @Override
+    public void update() {
+        if (target == null || target.getHealth() <= 0) {
+            target = targetingSys.acquireTarget();
+        }
+        if (target != null) {
+            int[] mv = path.getNextMove(getX(), getY(), target.getX(), target.getY());
+            setDx(mv[0]);
+            setDy(mv[1]);
+            super.update();
+            if (Math.hypot(target.getX()-getX(), target.getY()-getY()) <= 5) {
+                combat.performAttack(target);
+            }
+        }
+    }
+}

--- a/server/app/src/main/java/com/tavuc/models/entities/enemies/Enemy.java
+++ b/server/app/src/main/java/com/tavuc/models/entities/enemies/Enemy.java
@@ -1,0 +1,31 @@
+package com.tavuc.models.entities.enemies;
+
+import com.tavuc.ai.AIStateMachine;
+import com.tavuc.ai.PathfindingAgent;
+import com.tavuc.ai.TargetingSystem;
+import com.tavuc.ai.CombatBehavior;
+import com.tavuc.ai.DifficultyScaling;
+import com.tavuc.models.entities.Entity;
+
+/**
+ * Base class for all enemy entities on the server.
+ */
+public abstract class Enemy extends Entity {
+    protected AIStateMachine stateMachine;
+    protected PathfindingAgent pathfinding;
+    protected TargetingSystem targeting;
+    protected CombatBehavior combatBehavior;
+    protected EnemyType type;
+    protected DifficultyScaling scaling;
+
+    public Enemy(int id, String name, int x, int y, double health, int width, int height, EnemyType type) {
+        super(id, name, x, y, health, width, height);
+        this.type = type;
+        this.stateMachine = new AIStateMachine();
+        this.scaling = new DifficultyScaling();
+    }
+
+    public AIStateMachine getStateMachine() {
+        return stateMachine;
+    }
+}

--- a/server/app/src/main/java/com/tavuc/models/entities/enemies/EnemyType.java
+++ b/server/app/src/main/java/com/tavuc/models/entities/enemies/EnemyType.java
@@ -1,0 +1,9 @@
+package com.tavuc.models.entities.enemies;
+
+/**
+ * Different enemy categories used by the server.
+ */
+public enum EnemyType {
+    TROOPER,
+    MECH
+}

--- a/server/app/src/main/java/com/tavuc/models/entities/enemies/Mech.java
+++ b/server/app/src/main/java/com/tavuc/models/entities/enemies/Mech.java
@@ -1,0 +1,15 @@
+package com.tavuc.models.entities.enemies;
+
+/**
+ * Heavy mech enemy for the server.
+ */
+public abstract class Mech extends Enemy {
+    private Object charge;
+    private Object combos;
+    private Object armor;
+    private Object weakPoints;
+
+    public Mech(int id, String name, int x, int y, double health, int width, int height) {
+        super(id, name, x, y, health, width, height, EnemyType.MECH);
+    }
+}

--- a/server/app/src/main/java/com/tavuc/models/entities/enemies/Trooper.java
+++ b/server/app/src/main/java/com/tavuc/models/entities/enemies/Trooper.java
@@ -1,0 +1,20 @@
+package com.tavuc.models.entities.enemies;
+
+/**
+ * Basic trooper enemy implementation for the server.
+ */
+public abstract class Trooper extends Enemy {
+    private TrooperWeapon weapon;
+    private Object coverSystem;
+    private Object formation;
+    private Object suppression;
+
+    public Trooper(int id, String name, int x, int y, double health, int width, int height, TrooperWeapon weapon) {
+        super(id, name, x, y, health, width, height, EnemyType.TROOPER);
+        this.weapon = weapon;
+    }
+
+    public TrooperWeapon getWeapon() {
+        return weapon;
+    }
+}

--- a/server/app/src/main/java/com/tavuc/models/entities/enemies/TrooperWeapon.java
+++ b/server/app/src/main/java/com/tavuc/models/entities/enemies/TrooperWeapon.java
@@ -1,0 +1,10 @@
+package com.tavuc.models.entities.enemies;
+
+/**
+ * Weapon types for troopers on the server.
+ */
+public enum TrooperWeapon {
+    BLASTER,
+    LAUNCHER,
+    RIFLE
+}


### PR DESCRIPTION
## Summary
- add A* pathfinder and targeting/attack behaviors
- implement simple AIDirector difficulty logic
- create minimal trooper and mech enemy implementations
- flesh out wave manager and configuration
- expand tests for new AI utilities

## Testing
- `./run_all_tests.sh`

------
https://chatgpt.com/codex/tasks/task_e_68459152da208331bb7b68d41cc81fa3