### PR TITLE
Add wave timing and spawn pattern logic

### DIFF
--- a/client/app/src/main/java/com/tavuc/ai/WaveManager.java
+++ b/client/app/src/main/java/com/tavuc/ai/WaveManager.java
@@ -2,6 +2,8 @@ package com.tavuc.ai;
 
 import com.tavuc.managers.WorldManager;
 import com.tavuc.models.entities.enemies.*;
+import java.time.Duration;
+import java.time.Instant;
 import java.util.*;
 
 /**
@@ -11,6 +13,7 @@ public class WaveManager {
     private WaveConfiguration currentWave;
     private List<WaveConfiguration> waves = new ArrayList<>();
     private int index = 0;
+    private Instant waveStart;
 
     public void setWaves(List<WaveConfiguration> waves) {
         this.waves = waves;
@@ -20,11 +23,17 @@ public class WaveManager {
     public List<Enemy> spawnNextWave(WorldManager world) {
         if (index >= waves.size()) return Collections.emptyList();
         currentWave = waves.get(index++);
+        waveStart = Instant.now();
+
+        double difficulty = 1.0 + (currentWave.getWaveNumber() - 1) * 0.5;
         List<Enemy> spawned = new ArrayList<>();
         for (EnemySpawnData data : currentWave.getEnemies()) {
-            for (int i = 0; i < data.count(); i++) {
-                double x = 50 + i*5;
-                double y = 50 + i*5;
+            int count = (int) Math.ceil(data.count() * difficulty);
+            List<double[]> positions = generatePositions(count, currentWave.getSpawnPattern(), world);
+            for (int i = 0; i < count; i++) {
+                double[] pos = positions.get(i);
+                double x = pos[0];
+                double y = pos[1];
                 if (data.type() == EnemyType.TROOPER) {
                     spawned.add(new BasicTrooper(x, y, world, TrooperWeapon.BLASTER, i));
                 } else if (data.type() == EnemyType.MECH) {
@@ -41,5 +50,58 @@ public class WaveManager {
 
     public void setCurrentWave(WaveConfiguration wave) {
         this.currentWave = wave;
+    }
+
+    /** Returns true if the current wave exceeded its time limit. */
+    public boolean isCurrentWaveTimedOut() {
+        return currentWave != null && currentWave.getTimeLimit() != null &&
+                Instant.now().isAfter(waveStart.plus(currentWave.getTimeLimit()));
+    }
+
+    /** Whether more waves remain to be spawned. */
+    public boolean hasMoreWaves() {
+        return index < waves.size();
+    }
+
+    private List<double[]> generatePositions(int count, SpawnPattern pattern, WorldManager world) {
+        List<double[]> pos = new ArrayList<>();
+        Random r = new Random();
+        switch (pattern) {
+            case PERIMETER -> {
+                for (int i = 0; i < count; i++) {
+                    int side = i % 4;
+                    int p = (i / 4) * 10;
+                    switch (side) {
+                        case 0 -> pos.add(new double[]{0, p});
+                        case 1 -> pos.add(new double[]{100, p});
+                        case 2 -> pos.add(new double[]{p, 0});
+                        default -> pos.add(new double[]{p, 100});
+                    }
+                }
+            }
+            case DROP_POD -> {
+                for (int i = 0; i < count; i++) {
+                    pos.add(new double[]{50 + r.nextInt(11) - 5, 50 + r.nextInt(11) - 5});
+                }
+            }
+            case TELEPORT -> {
+                double baseX = 50;
+                double baseY = 50;
+                for (int i = 0; i < count; i++) {
+                    pos.add(new double[]{baseX + r.nextInt(11) - 5, baseY + r.nextInt(11) - 5});
+                }
+            }
+            case REINFORCEMENT -> {
+                for (int i = 0; i < count; i++) {
+                    pos.add(new double[]{10 + r.nextInt(10), 10 + r.nextInt(10)});
+                }
+            }
+            default -> {
+                for (int i = 0; i < count; i++) {
+                    pos.add(new double[]{10 + r.nextInt(10), 10 + r.nextInt(10)});
+                }
+            }
+        }
+        return pos;
     }
 }

--- a/server/app/src/main/java/com/tavuc/ai/WaveManager.java
+++ b/server/app/src/main/java/com/tavuc/ai/WaveManager.java
@@ -2,6 +2,8 @@ package com.tavuc.ai;
 
 import com.tavuc.models.entities.enemies.*;
 import com.tavuc.models.entities.Entity;
+import java.time.Duration;
+import java.time.Instant;
 import java.util.*;
 
 /**
@@ -11,6 +13,7 @@ public class WaveManager {
     private WaveConfiguration currentWave;
     private List<WaveConfiguration> waves = new ArrayList<>();
     private int index = 0;
+    private Instant waveStart;
 
     public void setWaves(List<WaveConfiguration> waves) {
         this.waves = waves;
@@ -20,11 +23,17 @@ public class WaveManager {
     public List<Enemy> spawnNextWave(boolean[][] blocked, Entity target) {
         if (index >= waves.size()) return Collections.emptyList();
         currentWave = waves.get(index++);
+        waveStart = Instant.now();
+
+        double difficulty = 1.0 + (currentWave.getWaveNumber() - 1) * 0.5;
         List<Enemy> spawned = new ArrayList<>();
         for (EnemySpawnData data : currentWave.getEnemies()) {
-            for (int i = 0; i < data.count(); i++) {
-                int x = 50 + i*5;
-                int y = 50 + i*5;
+            int count = (int) Math.ceil(data.count() * difficulty);
+            List<int[]> positions = generatePositions(count, currentWave.getSpawnPattern(), target);
+            for (int i = 0; i < count; i++) {
+                int[] pos = positions.get(i);
+                int x = pos[0];
+                int y = pos[1];
                 if (data.type() == EnemyType.TROOPER) {
                     spawned.add(new BasicTrooper(i, "t", x, y, TrooperWeapon.BLASTER, blocked, target, i));
                 } else if (data.type() == EnemyType.MECH) {
@@ -37,5 +46,58 @@ public class WaveManager {
 
     public WaveConfiguration getCurrentWave() {
         return currentWave;
+    }
+
+    /** Returns true if the current wave has exceeded its time limit. */
+    public boolean isCurrentWaveTimedOut() {
+        return currentWave != null && currentWave.getTimeLimit() != null &&
+                Instant.now().isAfter(waveStart.plus(currentWave.getTimeLimit()));
+    }
+
+    /** Whether there are more waves remaining. */
+    public boolean hasMoreWaves() {
+        return index < waves.size();
+    }
+
+    private List<int[]> generatePositions(int count, SpawnPattern pattern, Entity target) {
+        List<int[]> pos = new ArrayList<>();
+        Random r = new Random();
+        switch (pattern) {
+            case PERIMETER -> {
+                for (int i = 0; i < count; i++) {
+                    int side = i % 4;
+                    int p = (i / 4) * 10;
+                    switch (side) {
+                        case 0 -> pos.add(new int[]{0, p});
+                        case 1 -> pos.add(new int[]{100, p});
+                        case 2 -> pos.add(new int[]{p, 0});
+                        default -> pos.add(new int[]{p, 100});
+                    }
+                }
+            }
+            case DROP_POD -> {
+                for (int i = 0; i < count; i++) {
+                    pos.add(new int[]{50 + r.nextInt(11) - 5, 50 + r.nextInt(11) - 5});
+                }
+            }
+            case TELEPORT -> {
+                int baseX = target != null ? target.getX() : 50;
+                int baseY = target != null ? target.getY() : 50;
+                for (int i = 0; i < count; i++) {
+                    pos.add(new int[]{baseX + r.nextInt(11) - 5, baseY + r.nextInt(11) - 5});
+                }
+            }
+            case REINFORCEMENT -> {
+                for (int i = 0; i < count; i++) {
+                    pos.add(new int[]{10 + r.nextInt(10), 10 + r.nextInt(10)});
+                }
+            }
+            default -> {
+                for (int i = 0; i < count; i++) {
+                    pos.add(new int[]{10 + r.nextInt(10), 10 + r.nextInt(10)});
+                }
+            }
+        }
+        return pos;
     }
 }

--- a/server/app/src/test/java/com/tavuc/ai/WaveManagerTest.java
+++ b/server/app/src/test/java/com/tavuc/ai/WaveManagerTest.java
@@ -1,0 +1,59 @@
+package com.tavuc.ai;
+
+import com.tavuc.models.entities.Player;
+import com.tavuc.models.entities.enemies.Enemy;
+import com.tavuc.models.entities.enemies.EnemyType;
+import org.junit.Test;
+import java.time.Duration;
+import java.util.Arrays;
+import java.util.List;
+import static org.junit.Assert.*;
+
+public class WaveManagerTest {
+    @Test
+    public void waveProgressionAndScaling() {
+        WaveConfiguration w1 = new WaveConfiguration();
+        w1.setWaveNumber(1);
+        w1.setTimeLimit(Duration.ofSeconds(1));
+        w1.setSpawnPattern(SpawnPattern.PERIMETER);
+        w1.setEnemies(List.of(new EnemySpawnData(EnemyType.TROOPER, 1)));
+
+        WaveConfiguration w2 = new WaveConfiguration();
+        w2.setWaveNumber(2);
+        w2.setTimeLimit(Duration.ofSeconds(1));
+        w2.setSpawnPattern(SpawnPattern.PERIMETER);
+        w2.setEnemies(List.of(new EnemySpawnData(EnemyType.TROOPER, 1)));
+
+        WaveManager wm = new WaveManager();
+        wm.setWaves(Arrays.asList(w1, w2));
+
+        boolean[][] blocked = new boolean[10][10];
+        Player target = new Player(1, "p", "pw");
+
+        List<Enemy> first = wm.spawnNextWave(blocked, target);
+        assertEquals(1, first.size());
+        assertEquals(1, wm.getCurrentWave().getWaveNumber());
+
+        List<Enemy> second = wm.spawnNextWave(blocked, target);
+        assertEquals(2, second.size());
+        assertEquals(2, wm.getCurrentWave().getWaveNumber());
+    }
+
+    @Test
+    public void waveTimeLimitExpires() throws Exception {
+        WaveConfiguration w = new WaveConfiguration();
+        w.setWaveNumber(1);
+        w.setTimeLimit(Duration.ofMillis(1));
+        w.setSpawnPattern(SpawnPattern.PERIMETER);
+        w.setEnemies(List.of(new EnemySpawnData(EnemyType.TROOPER, 1)));
+
+        WaveManager wm = new WaveManager();
+        wm.setWaves(List.of(w));
+        boolean[][] blocked = new boolean[1][1];
+        Player target = new Player(1, "p", "pw");
+
+        wm.spawnNextWave(blocked, target);
+        Thread.sleep(5);
+        assertTrue(wm.isCurrentWaveTimedOut());
+    }
+}


### PR DESCRIPTION
## Summary
- handle spawn patterns and wave time limits in `WaveManager`
- scale enemy counts based on wave number
- add helper methods for wave state
- create unit tests for wave progression and timeouts

## Testing
- `./run_all_tests.sh`

------
https://chatgpt.com/codex/tasks/task_e_6845ad5a8a088331a7680215694d10a5