### PR TITLE
Implement remaining Phase 1-3 features

### DIFF
--- a/client/app/src/main/java/com/tavuc/ai/BasicCombatBehavior.java
+++ b/client/app/src/main/java/com/tavuc/ai/BasicCombatBehavior.java
@@ -1,6 +1,8 @@
 package com.tavuc.ai;
 
 import com.tavuc.models.entities.Entity;
+import com.tavuc.models.entities.enemies.Mech;
+import com.tavuc.ecs.systems.WeakPointSystem;
 
 /**
  * Simple combat behavior that damages the target if within range.
@@ -23,7 +25,12 @@ public class BasicCombatBehavior implements CombatBehavior {
         double dx = target.getX() - attacker.getX();
         double dy = target.getY() - attacker.getY();
         if (Math.hypot(dx, dy) <= range) {
-            target.takeDamage(damage);
+            int dmg = damage;
+            if (target instanceof Mech) {
+                WeakPointSystem wps = new WeakPointSystem();
+                dmg = wps.applyWeakPointDamage(attacker, target, damage);
+            }
+            target.takeDamage(dmg);
         }
     }
 }

--- a/client/app/src/main/java/com/tavuc/controllers/InputBuffer.java
+++ b/client/app/src/main/java/com/tavuc/controllers/InputBuffer.java
@@ -17,7 +17,11 @@ public class InputBuffer {
         MOVE_LEFT,
         MOVE_RIGHT,
         SLIDE,
-        DODGE
+        DODGE,
+        WEAPON_SWITCH,
+        ABILITY_ONE,
+        ABILITY_TWO,
+        ABILITY_THREE
     }
 
     public static class InputCommand {
@@ -43,6 +47,10 @@ public class InputBuffer {
         priorityMap.put(KeyBinding.MOVE_RIGHT, 3);
         priorityMap.put(KeyBinding.SLIDE, 2);
         priorityMap.put(KeyBinding.DODGE, 2);
+        priorityMap.put(KeyBinding.WEAPON_SWITCH, 2);
+        priorityMap.put(KeyBinding.ABILITY_ONE, 1);
+        priorityMap.put(KeyBinding.ABILITY_TWO, 1);
+        priorityMap.put(KeyBinding.ABILITY_THREE, 1);
     }
 
     /** Registers an input event for the given binding. */

--- a/client/app/src/main/java/com/tavuc/managers/InputManager.java
+++ b/client/app/src/main/java/com/tavuc/managers/InputManager.java
@@ -132,6 +132,9 @@ public class InputManager implements KeyListener {
                 rightPressed = true;
                 inputBuffer.registerInput(KeyBinding.MOVE_RIGHT);
             }
+            if (keyCode == KeyEvent.VK_R) {
+                inputBuffer.registerInput(KeyBinding.WEAPON_SWITCH);
+            }
             if (keyCode == KeyEvent.VK_TAB && forcePowers != null) {
                 forcePowers.cycleTarget(player);
             }
@@ -145,6 +148,20 @@ public class InputManager implements KeyListener {
                 if (player != null) {
                     player.getMovementController().dodge();
                     player.startDodgeInvulnerability(0.5);
+                }
+            }
+            if (forcePowers != null) {
+                if (keyCode == KeyEvent.VK_F1) {
+                    inputBuffer.registerInput(KeyBinding.ABILITY_ONE);
+                    forcePowers.secondaryAttack(player);
+                }
+                if (keyCode == KeyEvent.VK_F2) {
+                    inputBuffer.registerInput(KeyBinding.ABILITY_TWO);
+                    forcePowers.primaryAttack(player, null);
+                }
+                if (keyCode == KeyEvent.VK_F3) {
+                    inputBuffer.registerInput(KeyBinding.ABILITY_THREE);
+                    forcePowers.choke(player);
                 }
             }
             updatePlayerMovementInput();

--- a/client/app/src/main/java/com/tavuc/weapons/ForcePowers.java
+++ b/client/app/src/main/java/com/tavuc/weapons/ForcePowers.java
@@ -81,13 +81,27 @@ public class ForcePowers extends Weapon {
         if (cd.isActive()) return;
         if (!forceEnergy.consume(10)) return;
 
-        if (ability == ForceAbility.FORCE_CHOKE) {
-            updateTargets(wielder);
-            if (currentTarget == null) return;
-            double dx = currentTarget.getX() - wielder.getX();
-            double dy = currentTarget.getY() - wielder.getY();
-            if (Math.hypot(dx, dy) > stats.getRange()) return;
-            Client.sendForceAbility(wielder.getPlayerId(), currentTarget.getPlayerId(), ability.name());
+        updateTargets(wielder);
+
+        switch (ability) {
+            case FORCE_CHOKE -> {
+                if (currentTarget == null) return;
+                double dx = currentTarget.getX() - wielder.getX();
+                double dy = currentTarget.getY() - wielder.getY();
+                if (Math.hypot(dx, dy) > stats.getRange()) return;
+                Client.sendForceAbility(wielder.getPlayerId(), currentTarget.getPlayerId(), ability.name());
+            }
+            case FORCE_PUSH -> {
+                if (currentTarget == null) return;
+                double dx = currentTarget.getX() - wielder.getX();
+                double dy = currentTarget.getY() - wielder.getY();
+                if (Math.hypot(dx, dy) > stats.getRange()) return;
+                Client.sendForceAbility(wielder.getPlayerId(), currentTarget.getPlayerId(), ability.name());
+            }
+            case FORCE_SLAM -> {
+                // AoE ability does not require a specific target
+                Client.sendForceAbility(wielder.getPlayerId(), -1, ability.name());
+            }
         }
 
         sounds.play("force_use");

--- a/server/app/src/main/java/com/tavuc/managers/GameManager.java
+++ b/server/app/src/main/java/com/tavuc/managers/GameManager.java
@@ -237,19 +237,48 @@ public class GameManager {
             if (p.getId() == attackerId) attacker = p;
             if (p.getId() == targetId) target = p;
         }
-        if (attacker == null || target == null) return;
+        if (attacker == null) return;
 
-        double dx = target.getX() - attacker.getX();
-        double dy = target.getY() - attacker.getY();
-        double distance = Math.hypot(dx, dy);
         double range = attacker.getAttackRange();
 
-        if (distance > range) {
-            System.out.println("GameService " + gameId + ": Force ability out of range");
-            return;
+        switch (ability) {
+            case "FORCE_SLAM" -> {
+                for (Player p : playerSessions.keySet()) {
+                    if (p == attacker) continue;
+                    double dx = p.getX() - attacker.getX();
+                    double dy = p.getY() - attacker.getY();
+                    if (Math.hypot(dx, dy) <= range) {
+                        applyAbilityDamage(attacker, p, 1.0);
+                    }
+                }
+            }
+            case "FORCE_PUSH" -> {
+                if (target == null) return;
+                double dx = target.getX() - attacker.getX();
+                double dy = target.getY() - attacker.getY();
+                double dist = Math.hypot(dx, dy);
+                if (dist > range) return;
+                if (dist != 0) {
+                    target.setDx(dx / dist * 5);
+                    target.setDy(dy / dist * 5);
+                }
+                applyAbilityDamage(attacker, target, 0.5);
+            }
+            case "FORCE_CHOKE" -> {
+                if (target == null) return;
+                double dx = target.getX() - attacker.getX();
+                double dy = target.getY() - attacker.getY();
+                if (Math.hypot(dx, dy) > range) return;
+                applyAbilityDamage(attacker, target, 1.5);
+            }
+            default -> {
+                if (target == null) return;
+                applyAbilityDamage(attacker, target, 1.0);
+            }
         }
+    }
 
-        double damage = 1.0; // simple fixed damage for all abilities
+    private void applyAbilityDamage(Player attacker, Player target, double damage) {
         target.takeDamage(damage);
 
         PlayerDamagedBroadcast dmg = new PlayerDamagedBroadcast(


### PR DESCRIPTION
## Summary
- extend `InputBuffer` to handle weapon switch and force ability keys
- map new bindings in `InputManager` and trigger force abilities
- add unique handling for each force power
- add weak‑point checks for mechs in `BasicCombatBehavior`
- implement ability-specific logic server side

## Testing
- `./run_all_tests.sh`

------
https://chatgpt.com/codex/tasks/task_e_6845b3ab08b08331a67b47ec10d01e15