### PR TITLE
Implement coin drop pickups

### DIFF
--- a/client/app/src/main/java/com/tavuc/Client.java
+++ b/client/app/src/main/java/com/tavuc/Client.java
@@ -46,6 +46,8 @@ import com.tavuc.networking.models.ProjectileUpdateBroadcast;
 import com.tavuc.networking.models.ProjectileRemovedBroadcast;
 import com.tavuc.networking.models.RegisterRequest;
 import com.tavuc.networking.models.RegisterResponse;
+import com.tavuc.networking.models.CoinDropSpawnedBroadcast;
+import com.tavuc.networking.models.CoinDropRemovedBroadcast;
 import com.tavuc.networking.models.RequestChunkRequest;
 import com.tavuc.networking.models.RequestChunkResponse;
 import com.tavuc.networking.models.RequestPaletteRequest;
@@ -57,6 +59,8 @@ import com.tavuc.networking.models.ShipUpdateBroadcast;
 import com.tavuc.networking.models.ShipDamagedBroadcast;
 import com.tavuc.networking.models.ShipDestroyedBroadcast;
 import com.tavuc.networking.models.ShipUpdateRequest;
+import com.tavuc.networking.models.ExtractionRequest;
+import com.tavuc.networking.models.CoinUpdateBroadcast;
 import com.tavuc.ui.panels.GamePanel;
 import com.tavuc.ui.panels.ISpacePanel;
 import com.tavuc.ui.panels.SpacePanel;
@@ -488,6 +492,18 @@ public class Client {
         out.println(gson.toJson(req));
     }
 
+    /**
+     * Sends a coin extraction request to the server.
+     */
+    public static void sendExtractionRequest(int playerId) {
+        if (out == null) {
+            System.err.println("Client not connected, cannot send extraction request.");
+            return;
+        }
+        ExtractionRequest req = new ExtractionRequest(String.valueOf(playerId));
+        out.println(gson.toJson(req));
+    }
+
 
 
     /**
@@ -677,6 +693,35 @@ public class Client {
                                     ProjectileRemovedBroadcast event = gson.fromJson(processedJson, ProjectileRemovedBroadcast.class);
                                     SwingUtilities.invokeLater(() -> currentSpacePanel.handleProjectileRemoved(event));
                                 }
+                                break;
+                            case "COIN_DROP_SPAWNED_BROADCAST":
+                                if (worldManager != null) {
+                                    CoinDropSpawnedBroadcast event = gson.fromJson(processedJson, CoinDropSpawnedBroadcast.class);
+                                    SwingUtilities.invokeLater(() -> worldManager.addCoinDrop(event));
+                                }
+                                break;
+                            case "COIN_DROP_REMOVED_BROADCAST":
+                                if (worldManager != null) {
+                                    CoinDropRemovedBroadcast event = gson.fromJson(processedJson, CoinDropRemovedBroadcast.class);
+                                    SwingUtilities.invokeLater(() -> worldManager.removeCoinDrop(event.dropId));
+                                }
+                                break;
+                            case "COIN_UPDATE_BROADCAST":
+                                CoinUpdateBroadcast coinEvent = gson.fromJson(processedJson, CoinUpdateBroadcast.class);
+                                SwingUtilities.invokeLater(() -> {
+                                    int pid = Integer.parseInt(coinEvent.playerId);
+                                    if (currentGamePanel != null && currentGamePanel.getPlayer().getPlayerId() == pid) {
+                                        currentGamePanel.getPlayer().setCoins(coinEvent.coins);
+                                    } else if (worldManager != null) {
+                                        Player other = worldManager.getOtherPlayer(pid);
+                                        if (other != null) {
+                                            other.setCoins(coinEvent.coins);
+                                        }
+                                    }
+                                    if (currentGamePanel != null) {
+                                        currentGamePanel.repaint();
+                                    }
+                                });
                                 break;
                             case "REQUEST_CHUNK_RESPONSE":
                                 if (worldManager != null) {

--- a/client/app/src/main/java/com/tavuc/managers/InputManager.java
+++ b/client/app/src/main/java/com/tavuc/managers/InputManager.java
@@ -143,6 +143,9 @@ public class InputManager implements KeyListener {
                 inputBuffer.registerInput(KeyBinding.SLIDE);
                 if (player != null) player.getMovementController().startSlide();
             }
+            if (keyCode == KeyEvent.VK_E && player != null) {
+                Client.sendExtractionRequest(player.getPlayerId());
+            }
             if (keyCode == KeyEvent.VK_SPACE) {
                 inputBuffer.registerInput(KeyBinding.DODGE);
                 if (player != null) {

--- a/client/app/src/main/java/com/tavuc/managers/WorldManager.java
+++ b/client/app/src/main/java/com/tavuc/managers/WorldManager.java
@@ -12,6 +12,8 @@ import com.tavuc.models.entities.Player; // Added import
 import com.tavuc.Client;
 import com.tavuc.networking.models.PlayerJoinedBroadcast; // Added import
 import com.tavuc.networking.models.PlayerMovedBroadcast; // Added import
+import com.tavuc.networking.models.CoinDropSpawnedBroadcast;
+import com.tavuc.networking.models.CoinDropRemovedBroadcast;
 import com.tavuc.models.planets.Chunk;
 import com.tavuc.models.planets.ColorPallete;
 import com.tavuc.models.planets.ColorType;
@@ -28,6 +30,7 @@ public class WorldManager {
     private static final int chunkLoadRadius = 2; 
     private static final Gson gson = new Gson();
     private final Map<Integer, Player> otherPlayers = new ConcurrentHashMap<>(); // Added for other players
+    private final Map<String, com.tavuc.models.items.CoinDrop> coinDrops = new ConcurrentHashMap<>();
 
     public WorldManager(int gameId) {
         this.gameId = gameId;
@@ -100,6 +103,21 @@ public class WorldManager {
         } catch (NumberFormatException e) {
             System.err.println("WorldManager: Error parsing playerId for removePlayer: " + playerId);
         }
+    }
+
+    public void addCoinDrop(CoinDropSpawnedBroadcast event) {
+        coinDrops.put(event.dropId, new com.tavuc.models.items.CoinDrop(event.dropId, event.x, event.y, event.amount));
+        if (Client.currentGamePanel != null) Client.currentGamePanel.repaint();
+    }
+
+    public void removeCoinDrop(String dropId) {
+        if (coinDrops.remove(dropId) != null && Client.currentGamePanel != null) {
+            Client.currentGamePanel.repaint();
+        }
+    }
+
+    public List<com.tavuc.models.items.CoinDrop> getCoinDrops() {
+        return new ArrayList<>(coinDrops.values());
     }
 
     public void setGameId(int gameId) {

--- a/client/app/src/main/java/com/tavuc/models/entities/Player.java
+++ b/client/app/src/main/java/com/tavuc/models/entities/Player.java
@@ -33,6 +33,8 @@ public class Player extends Entity {
     private int lastSentY; 
     private double lastSentDx;
     private double lastSentDy;
+    // Current amount of coins carried by the player
+    private int coins = 0;
     private static final int PLAYER_BASE_WIDTH = 120;
     private static final int PLAYER_BASE_HEIGHT = 120;
     private static final int HAND_SIZE = 60;
@@ -67,6 +69,7 @@ public class Player extends Entity {
         this.lastSentDx = this.dx;
         this.lastSentDy = this.dy;
         this.lastSentDirection = 0.0;
+        this.coins = 0;
 
 
         updatePlayerShapes();
@@ -445,6 +448,28 @@ public class Player extends Entity {
      */
     public void setlastSentDirection(double angle) {
         this.lastSentDirection = angle;
+    }
+
+    /** Returns the number of coins currently carried by the player. */
+    public int getCoins() {
+        return coins;
+    }
+
+    /** Adds coins to the player's inventory. */
+    public void addCoins(int amount) {
+        this.coins += amount;
+    }
+
+    /** Directly sets the player's carried coin amount. */
+    public void setCoins(int amount) {
+        this.coins = amount;
+    }
+
+    /** Extracts all carried coins, resetting the count and returning the amount extracted. */
+    public int extractCoins() {
+        int extracted = this.coins;
+        this.coins = 0;
+        return extracted;
     }
 
     /**

--- a/client/app/src/main/java/com/tavuc/models/items/CoinDrop.java
+++ b/client/app/src/main/java/com/tavuc/models/items/CoinDrop.java
@@ -1,0 +1,28 @@
+package com.tavuc.models.items;
+
+import com.tavuc.models.GameObject;
+
+/** Client-side representation of a coin drop on the ground. */
+public class CoinDrop extends GameObject {
+    private final String id;
+    private final int amount;
+
+    public CoinDrop(String id, int x, int y, int amount) {
+        super(x, y, 20, 20);
+        this.id = id;
+        this.amount = amount;
+    }
+
+    public String getId() { return id; }
+    public int getAmount() { return amount; }
+
+    public void update() {
+        // Static item - no behaviour
+    }
+
+    @Override
+    public void draw(java.awt.Graphics2D g2d, double offsetX, double offsetY) {
+        g2d.setColor(java.awt.Color.YELLOW);
+        g2d.fillOval((int)(x - offsetX), (int)(y - offsetY), width, height);
+    }
+}

--- a/client/app/src/main/java/com/tavuc/networking/models/CoinDropRemovedBroadcast.java
+++ b/client/app/src/main/java/com/tavuc/networking/models/CoinDropRemovedBroadcast.java
@@ -1,0 +1,9 @@
+package com.tavuc.networking.models;
+
+public class CoinDropRemovedBroadcast extends BaseMessage {
+    public String dropId;
+
+    public CoinDropRemovedBroadcast() {
+        this.type = "COIN_DROP_REMOVED_BROADCAST";
+    }
+}

--- a/client/app/src/main/java/com/tavuc/networking/models/CoinDropSpawnedBroadcast.java
+++ b/client/app/src/main/java/com/tavuc/networking/models/CoinDropSpawnedBroadcast.java
@@ -1,0 +1,12 @@
+package com.tavuc.networking.models;
+
+public class CoinDropSpawnedBroadcast extends BaseMessage {
+    public String dropId;
+    public int x;
+    public int y;
+    public int amount;
+
+    public CoinDropSpawnedBroadcast() {
+        this.type = "COIN_DROP_SPAWNED_BROADCAST";
+    }
+}

--- a/client/app/src/main/java/com/tavuc/networking/models/CoinUpdateBroadcast.java
+++ b/client/app/src/main/java/com/tavuc/networking/models/CoinUpdateBroadcast.java
@@ -1,0 +1,10 @@
+package com.tavuc.networking.models;
+
+public class CoinUpdateBroadcast extends BaseMessage {
+    public String playerId;
+    public int coins;
+
+    public CoinUpdateBroadcast() {
+        this.type = "COIN_UPDATE_BROADCAST";
+    }
+}

--- a/client/app/src/main/java/com/tavuc/networking/models/ExtractionRequest.java
+++ b/client/app/src/main/java/com/tavuc/networking/models/ExtractionRequest.java
@@ -1,0 +1,14 @@
+package com.tavuc.networking.models;
+
+public class ExtractionRequest extends BaseMessage {
+    public String playerId;
+
+    public ExtractionRequest() {
+        this.type = "EXTRACTION_REQUEST";
+    }
+
+    public ExtractionRequest(String playerId) {
+        this();
+        this.playerId = playerId;
+    }
+}

--- a/client/app/src/main/java/com/tavuc/ui/panels/GamePanel.java
+++ b/client/app/src/main/java/com/tavuc/ui/panels/GamePanel.java
@@ -234,6 +234,13 @@ public class GamePanel extends GPanel implements ActionListener, MouseMotionList
             }
         }
 
+        // Draw coin drops
+        if (worldManager != null) {
+            g2d.setColor(Color.YELLOW);
+            for (com.tavuc.models.items.CoinDrop drop : worldManager.getCoinDrops()) {
+                g2d.fillOval(drop.getX(), drop.getY(), drop.getWidth(), drop.getHeight());
+            }
+        }
 
         int playerSize = 40;
         int handSize = playerSize / 3; // unused now but kept for compatibility
@@ -411,6 +418,14 @@ public class GamePanel extends GPanel implements ActionListener, MouseMotionList
                 null
             );
         }
+
+        // Display current coin count in the top-right corner
+        g2d.setColor(Color.YELLOW);
+        String coinText = "Coins: " + player.getCoins();
+        FontMetrics fmCoins = g2d.getFontMetrics();
+        int coinX = panelWidth - fmCoins.stringWidth(coinText) - 20;
+        int coinY = 20 + fmCoins.getAscent();
+        g2d.drawString(coinText, coinX, coinY);
 
         // Mana and ability display removed
     }

--- a/server/app/src/main/java/com/tavuc/models/entities/Player.java
+++ b/server/app/src/main/java/com/tavuc/models/entities/Player.java
@@ -19,6 +19,8 @@ public class Player extends Entity {
     // Increased default melee range to compliment larger player size
     private double attackRange = 60.0;
     // Player-specific combat settings
+    // Coins currently carried by this player
+    private int coins = 0;
 
     /**
      * Constructor for Player
@@ -37,6 +39,7 @@ public class Player extends Entity {
         this.lastSpaceX = 0.0; // Default to 0,0 or a system entry point
         this.lastSpaceY = 0.0;
         this.lastSpaceAngle = 0.0;
+        this.coins = 0;
     }
 
     /** 
@@ -109,6 +112,28 @@ public class Player extends Entity {
         this.attackRange = attackRange;
     }
 
+    /** Returns the amount of coins the player currently carries. */
+    public int getCoins() {
+        return coins;
+    }
+
+    /** Adds coins to the player. */
+    public void addCoins(int amount) {
+        this.coins += amount;
+    }
+
+    /** Directly sets the player's coin amount. */
+    public void setCoins(int amount) {
+        this.coins = amount;
+    }
+
+    /** Extracts all coins, resetting the count and returning the amount. */
+    public int extractCoins() {
+        int extracted = this.coins;
+        this.coins = 0;
+        return extracted;
+    }
+
     @Override
     public void takeDamage(double amount) {
         super.takeDamage(amount);
@@ -142,6 +167,7 @@ public class Player extends Entity {
             props.setProperty("lastSpaceX", String.valueOf(this.lastSpaceX));
             props.setProperty("lastSpaceY", String.valueOf(this.lastSpaceY));
             props.setProperty("lastSpaceAngle", String.valueOf(this.lastSpaceAngle));
+            props.setProperty("coins", String.valueOf(this.coins));
 
             try (BufferedWriter writer = Files.newBufferedWriter(playerFile)) {
                 props.store(writer, "Player data");
@@ -179,6 +205,7 @@ public class Player extends Entity {
             player.setLastSpaceX(Double.parseDouble(props.getProperty("lastSpaceX", "0.0")));
             player.setLastSpaceY(Double.parseDouble(props.getProperty("lastSpaceY", "0.0")));
             player.setLastSpaceAngle(Double.parseDouble(props.getProperty("lastSpaceAngle", "0.0")));
+            player.setCoins(Integer.parseInt(props.getProperty("coins", "0")));
             return player;
         } catch (IOException e) {
             System.err.println("[DEBUG Player.load] IOException for '" + username + "': " + e.getMessage()); 

--- a/server/app/src/main/java/com/tavuc/models/items/CoinDrop.java
+++ b/server/app/src/main/java/com/tavuc/models/items/CoinDrop.java
@@ -1,0 +1,23 @@
+package com.tavuc.models.items;
+
+import com.tavuc.models.GameObject;
+
+/** Simple coin drop item that can be picked up by players. */
+public class CoinDrop extends GameObject {
+    private final String id;
+    private final int amount;
+
+    public CoinDrop(String id, int x, int y, int amount) {
+        super(x, y, 20, 20);
+        this.id = id;
+        this.amount = amount;
+    }
+
+    public String getId() { return id; }
+    public int getAmount() { return amount; }
+
+    @Override
+    public void update() {
+        // Coin drops have no behaviour on their own
+    }
+}

--- a/server/app/src/main/java/com/tavuc/networking/ClientSession.java
+++ b/server/app/src/main/java/com/tavuc/networking/ClientSession.java
@@ -155,6 +155,9 @@ public class ClientSession implements Runnable {
                 case "FIRE_REQUEST":
                     handleFireRequest(jsonMessage);
                     break;
+                case "EXTRACTION_REQUEST":
+                    handleExtractionRequest(jsonMessage);
+                    break;
                 default:
                     sendMessage(gson.toJson(new ErrorMessage("UNKNOWN_COMMAND " + messageType)));
                     break;
@@ -670,4 +673,17 @@ public class ClientSession implements Runnable {
         // sendMessage(gson.toJson(new ErrorMessage("Weapon still on cooldown.")));
     }
 }
+
+    private void handleExtractionRequest(String jsonMessage) {
+        ExtractionRequest req = gson.fromJson(jsonMessage, ExtractionRequest.class);
+        if (currentGameService == null) {
+            sendMessage(gson.toJson(new ErrorMessage("Not in a game.")));
+            return;
+        }
+        if (player == null || !String.valueOf(player.getId()).equals(req.playerId)) {
+            sendMessage(gson.toJson(new ErrorMessage("Player ID mismatch or not authenticated.")));
+            return;
+        }
+        currentGameService.handleExtraction(player.getId());
+    }
 }

--- a/server/app/src/main/java/com/tavuc/networking/models/CoinDropRemovedBroadcast.java
+++ b/server/app/src/main/java/com/tavuc/networking/models/CoinDropRemovedBroadcast.java
@@ -1,0 +1,11 @@
+package com.tavuc.networking.models;
+
+public class CoinDropRemovedBroadcast extends BaseMessage {
+    public String dropId;
+
+    public CoinDropRemovedBroadcast(String dropId) {
+        super();
+        this.type = "COIN_DROP_REMOVED_BROADCAST";
+        this.dropId = dropId;
+    }
+}

--- a/server/app/src/main/java/com/tavuc/networking/models/CoinDropSpawnedBroadcast.java
+++ b/server/app/src/main/java/com/tavuc/networking/models/CoinDropSpawnedBroadcast.java
@@ -1,0 +1,17 @@
+package com.tavuc.networking.models;
+
+public class CoinDropSpawnedBroadcast extends BaseMessage {
+    public String dropId;
+    public int x;
+    public int y;
+    public int amount;
+
+    public CoinDropSpawnedBroadcast(String dropId, int x, int y, int amount) {
+        super();
+        this.type = "COIN_DROP_SPAWNED_BROADCAST";
+        this.dropId = dropId;
+        this.x = x;
+        this.y = y;
+        this.amount = amount;
+    }
+}

--- a/server/app/src/main/java/com/tavuc/networking/models/CoinUpdateBroadcast.java
+++ b/server/app/src/main/java/com/tavuc/networking/models/CoinUpdateBroadcast.java
@@ -1,0 +1,16 @@
+package com.tavuc.networking.models;
+
+public class CoinUpdateBroadcast extends BaseMessage {
+    public String playerId;
+    public int coins;
+
+    public CoinUpdateBroadcast() {
+        this.type = "COIN_UPDATE_BROADCAST";
+    }
+
+    public CoinUpdateBroadcast(String playerId, int coins) {
+        this();
+        this.playerId = playerId;
+        this.coins = coins;
+    }
+}

--- a/server/app/src/main/java/com/tavuc/networking/models/ExtractionRequest.java
+++ b/server/app/src/main/java/com/tavuc/networking/models/ExtractionRequest.java
@@ -1,0 +1,14 @@
+package com.tavuc.networking.models;
+
+public class ExtractionRequest extends BaseMessage {
+    public String playerId;
+
+    public ExtractionRequest() {
+        this.type = "EXTRACTION_REQUEST";
+    }
+
+    public ExtractionRequest(String playerId) {
+        this();
+        this.playerId = playerId;
+    }
+}

--- a/server/app/src/test/java/com/tavuc/CoinDropTest.java
+++ b/server/app/src/test/java/com/tavuc/CoinDropTest.java
@@ -1,0 +1,31 @@
+package com.tavuc;
+
+import com.tavuc.managers.GameManager;
+import com.tavuc.models.entities.Player;
+import com.tavuc.models.planets.Planet;
+import com.tavuc.models.planets.PlanetType;
+import org.junit.Test;
+import static org.junit.Assert.*;
+
+public class CoinDropTest {
+    private static class DummySession extends com.tavuc.networking.ClientSession {
+        DummySession() { super(new java.net.Socket(), new com.tavuc.managers.AuthManager(), new com.tavuc.managers.LobbyManager()); }
+        @Override public void sendMessage(Object o) {}
+    }
+
+    @Test
+    public void coinDropSpawnedOnDeath() {
+        GameManager gm = new GameManager();
+        Planet p = new Planet(1, "test", PlanetType.Desert, 10, 10, 1, 1, 1L, 0, 0);
+        gm.initialize(1, p, 2);
+        Player a = new Player(1, "a", "pw");
+        Player b = new Player(2, "b", "pw");
+        gm.addPlayer(a, new DummySession());
+        gm.addPlayer(b, new DummySession());
+        b.addCoins(5);
+        b.setHealth(0.2);
+        gm.handlePlayerAttack(a.getId(), b.getId());
+        assertEquals(1, gm.getCoinDrops().size());
+        assertEquals(0, b.getCoins());
+    }
+}

--- a/server/app/src/test/java/com/tavuc/CurrencyTest.java
+++ b/server/app/src/test/java/com/tavuc/CurrencyTest.java
@@ -1,0 +1,17 @@
+package com.tavuc;
+
+import com.tavuc.models.entities.Player;
+import org.junit.Test;
+import static org.junit.Assert.*;
+
+public class CurrencyTest {
+    @Test
+    public void coinsIncreaseAndResetOnExtraction() {
+        Player p = new Player(1, "tester", "pw");
+        p.addCoins(10);
+        assertEquals(10, p.getCoins());
+        int ex = p.extractCoins();
+        assertEquals(10, ex);
+        assertEquals(0, p.getCoins());
+    }
+}


### PR DESCRIPTION
## Summary
- create CoinDrop item type and spawn/remove broadcasts
- spawn coin drops when players die and on enemy kills
- track and pickup coin drops server-side, broadcasting updates
- draw and manage coin drops on the client
- add unit test verifying drops occur on player death

## Testing
- `./run_all_tests.sh`

------
https://chatgpt.com/codex/tasks/task_e_6845e70c86688331b61a07353650bc91