### PR TITLE
Implement basic server wave spawning

### DIFF
--- a/server/app/src/test/java/com/tavuc/GameWaveSpawnTest.java
+++ b/server/app/src/test/java/com/tavuc/GameWaveSpawnTest.java
@@ -1,0 +1,26 @@
+package com.tavuc;
+
+import com.tavuc.managers.GameManager;
+import com.tavuc.models.entities.Player;
+import com.tavuc.models.planets.Planet;
+import com.tavuc.models.planets.PlanetType;
+import org.junit.Test;
+import static org.junit.Assert.*;
+
+public class GameWaveSpawnTest {
+    private static class DummySession extends com.tavuc.networking.ClientSession {
+        DummySession() { super(new java.net.Socket(), new com.tavuc.managers.AuthManager(), new com.tavuc.managers.LobbyManager()); }
+        @Override public void sendMessage(Object o) {}
+    }
+
+    @Test
+    public void firstWaveSpawnsOnGameStart() {
+        GameManager gm = new GameManager();
+        Planet p = new Planet(1, "test", PlanetType.Desert, 10, 10, 1, 1, 1L, 0, 0);
+        gm.initialize(1, p, 2);
+        Player player = new Player(1, "a", "pw");
+        gm.addPlayer(player, new DummySession());
+        gm.update();
+        assertTrue(gm.getActiveEnemies().size() > 0);
+    }
+}


### PR DESCRIPTION
## Summary
- add `WaveManager` to `GameManager` and initialize with simple waves
- spawn waves and update enemies during the game update loop
- expose active enemies list
- add a test verifying that a wave spawns when a game starts

## Testing
- `./run_all_tests.sh`

------
https://chatgpt.com/codex/tasks/task_e_684609cdb68c8331b4b530346759c5db