### PR TITLE
Enable Force powers to affect enemies

### DIFF
--- a/client/app/src/main/java/com/tavuc/ai/WaveManager.java
+++ b/client/app/src/main/java/com/tavuc/ai/WaveManager.java
@@ -14,6 +14,7 @@ public class WaveManager {
     private List<WaveConfiguration> waves = new ArrayList<>();
     private int index = 0;
     private Instant waveStart;
+    private int nextId = 1;
 
     public void setWaves(List<WaveConfiguration> waves) {
         this.waves = waves;
@@ -34,10 +35,11 @@ public class WaveManager {
                 double[] pos = positions.get(i);
                 double x = pos[0];
                 double y = pos[1];
+                int id = nextId++;
                 if (data.type() == EnemyType.TROOPER) {
-                    spawned.add(new BasicTrooper(x, y, world, TrooperWeapon.BLASTER, i));
+                    spawned.add(new BasicTrooper(id, x, y, world, TrooperWeapon.BLASTER, i));
                 } else if (data.type() == EnemyType.MECH) {
-                    spawned.add(new BasicMech(x, y, world));
+                    spawned.add(new BasicMech(id, x, y, world));
                 }
             }
         }

--- a/client/app/src/main/java/com/tavuc/managers/WorldManager.java
+++ b/client/app/src/main/java/com/tavuc/managers/WorldManager.java
@@ -29,7 +29,8 @@ public class WorldManager {
     public static final int TILE_SIZE = 32; 
     private static final int chunkLoadRadius = 2; 
     private static final Gson gson = new Gson();
-    private final Map<Integer, Player> otherPlayers = new ConcurrentHashMap<>(); // Added for other players
+    private final Map<Integer, Player> otherPlayers = new ConcurrentHashMap<>();
+    private final Map<Integer, com.tavuc.models.entities.enemies.Enemy> enemies = new ConcurrentHashMap<>();
     private final Map<String, com.tavuc.models.items.CoinDrop> coinDrops = new ConcurrentHashMap<>();
 
     public WorldManager(int gameId) {
@@ -40,6 +41,24 @@ public class WorldManager {
 
     public List<Player> getOtherPlayers() {
         return new ArrayList<>(otherPlayers.values());
+    }
+
+    /** Returns current active enemies. */
+    public List<com.tavuc.models.entities.enemies.Enemy> getEnemies() {
+        return new ArrayList<>(enemies.values());
+    }
+
+    public void addEnemy(com.tavuc.models.entities.enemies.Enemy e) {
+        if (e != null) {
+            enemies.put(e.getId(), e);
+            if (Client.currentGamePanel != null) Client.currentGamePanel.repaint();
+        }
+    }
+
+    public void removeEnemy(int id) {
+        if (enemies.remove(id) != null && Client.currentGamePanel != null) {
+            Client.currentGamePanel.repaint();
+        }
     }
 
     public Player getOtherPlayer(int id) {
@@ -222,6 +241,7 @@ public class WorldManager {
     public void clearChunks() {
         chunks.clear();
         otherPlayers.clear();
+        enemies.clear();
     }
 
     public Tile getTileAt(int worldX, int worldY) {

--- a/client/app/src/main/java/com/tavuc/models/entities/enemies/BasicMech.java
+++ b/client/app/src/main/java/com/tavuc/models/entities/enemies/BasicMech.java
@@ -21,8 +21,8 @@ public class BasicMech extends Mech implements TargetHolder {
         return Math.hypot(target.getX() - getX(), target.getY() - getY());
     }
 
-    public BasicMech(double x, double y, WorldManager world) {
-        super(x, y, 30, 30, 1.5, 10);
+    public BasicMech(int id, double x, double y, WorldManager world) {
+        super(id, x, y, 30, 30, 1.5, 10);
         this.world = world;
         this.pathfinding = new BasicPathfindingAgent(world);
         this.targeting = new BasicTargetingSystem(world, this);

--- a/client/app/src/main/java/com/tavuc/models/entities/enemies/BasicTrooper.java
+++ b/client/app/src/main/java/com/tavuc/models/entities/enemies/BasicTrooper.java
@@ -24,8 +24,8 @@ public class BasicTrooper extends Trooper implements TargetHolder {
         return Math.hypot(target.getX() - getX(), target.getY() - getY());
     }
 
-    public BasicTrooper(double x, double y, WorldManager world, TrooperWeapon weapon, int formationIndex) {
-        super(x, y, 20, 20, 2.0, 5, weapon, formationIndex);
+    public BasicTrooper(int id, double x, double y, WorldManager world, TrooperWeapon weapon, int formationIndex) {
+        super(id, x, y, 20, 20, 2.0, 5, weapon, formationIndex);
         this.world = world;
         this.pathfinding = new BasicPathfindingAgent(world);
         this.targeting = new BasicTargetingSystem(world, this);

--- a/client/app/src/main/java/com/tavuc/models/entities/enemies/Enemy.java
+++ b/client/app/src/main/java/com/tavuc/models/entities/enemies/Enemy.java
@@ -17,11 +17,14 @@ public abstract class Enemy extends Entity {
     protected CombatBehavior combatBehavior;
     protected EnemyType type;
     protected DifficultyScaling scaling;
+    /** Unique identifier for this enemy. */
+    protected int id;
     /** Direction the enemy is facing in radians. */
     protected double direction;
 
-    public Enemy(double x, double y, int width, int height, double velocity, int maxHealth, EnemyType type) {
+    public Enemy(int id, double x, double y, int width, int height, double velocity, int maxHealth, EnemyType type) {
         super(x, y, width, height, velocity, maxHealth);
+        this.id = id;
         this.type = type;
         this.stateMachine = new AIStateMachine();
         this.scaling = new DifficultyScaling();
@@ -40,5 +43,10 @@ public abstract class Enemy extends Entity {
     /** Sets the facing direction in radians. */
     public void setDirection(double direction) {
         this.direction = direction;
+    }
+
+    /** Returns this enemy's unique ID. */
+    public int getId() {
+        return id;
     }
 }

--- a/client/app/src/main/java/com/tavuc/models/entities/enemies/Mech.java
+++ b/client/app/src/main/java/com/tavuc/models/entities/enemies/Mech.java
@@ -15,8 +15,8 @@ public abstract class Mech extends Enemy {
     private int comboHits;
     private double slamRadius = 30;
 
-    public Mech(double x, double y, int width, int height, double velocity, int maxHealth) {
-        super(x, y, width, height, velocity, maxHealth, EnemyType.MECH);
+    public Mech(int id, double x, double y, int width, int height, double velocity, int maxHealth) {
+        super(id, x, y, width, height, velocity, maxHealth, EnemyType.MECH);
     }
 
     /** Performs a quick charge toward the target and attempts an attack. */

--- a/client/app/src/main/java/com/tavuc/models/entities/enemies/Trooper.java
+++ b/client/app/src/main/java/com/tavuc/models/entities/enemies/Trooper.java
@@ -18,9 +18,9 @@ public abstract class Trooper extends Enemy {
     protected final SuppressionBehavior suppression;
     protected int formationIndex;
 
-    public Trooper(double x, double y, int width, int height, double velocity, int maxHealth,
+    public Trooper(int id, double x, double y, int width, int height, double velocity, int maxHealth,
                    TrooperWeapon weapon, int formationIndex) {
-        super(x, y, width, height, velocity, maxHealth, EnemyType.TROOPER);
+        super(id, x, y, width, height, velocity, maxHealth, EnemyType.TROOPER);
         this.weapon = weapon;
         this.coverSystem = new CoverSystem();
         this.formation = new FormationController(4);

--- a/client/app/src/main/java/com/tavuc/ui/panels/GamePanel.java
+++ b/client/app/src/main/java/com/tavuc/ui/panels/GamePanel.java
@@ -7,6 +7,9 @@ import javax.swing.Timer;
 import com.tavuc.Client;
 import com.tavuc.managers.InputManager;
 import com.tavuc.managers.WorldManager;
+import com.tavuc.weapons.ForceAlignment;
+import com.tavuc.weapons.ForcePowers;
+import com.tavuc.weapons.WeaponStats;
 import com.tavuc.models.entities.Player;
 import com.tavuc.models.planets.Chunk;
 import com.tavuc.models.planets.ColorPallete;
@@ -54,6 +57,7 @@ public class GamePanel extends GPanel implements ActionListener, MouseMotionList
     private int gameId; 
     private Player player;
     private InputManager inputManager;
+    private ForcePowers forcePowers;
     private Timer gameLoopTimer;
     // private Map<Integer, Player> otherPlayers = new ConcurrentHashMap<>(); // Managed by WorldManager
     private Timer playerUpdateRequester;
@@ -102,6 +106,13 @@ public class GamePanel extends GPanel implements ActionListener, MouseMotionList
         this.inputManager = InputManager.getInstance();
         this.inputManager.setPlayerTarget(this.player);
         this.inputManager.setControlTarget(InputManager.ControlTargetType.PLAYER);
+        this.forcePowers = new ForcePowers(
+                100,
+                ForceAlignment.LIGHT,
+                new WeaponStats(1, this.player.getAttackRange(), 1.0)
+        );
+        this.inputManager.setForcePowers(this.forcePowers);
+        System.out.println("Force powers unlocked! Press F1-F3 to use abilities.");
 
         // Use Client's WorldManager if available, otherwise create a new one
         if (Client.worldManager != null && Client.worldManager.getGameId() == gameId) {

--- a/client/app/src/test/java/com/tavuc/ai/TacticalCoordinatorTest.java
+++ b/client/app/src/test/java/com/tavuc/ai/TacticalCoordinatorTest.java
@@ -14,8 +14,8 @@ public class TacticalCoordinatorTest {
     @Test
     public void shareTargetAssignsSameTarget() {
         WorldManager wm = new WorldManager(0);
-        BasicTrooper t1 = new BasicTrooper(0,0, wm, TrooperWeapon.RIFLE,0);
-        BasicTrooper t2 = new BasicTrooper(10,0, wm, TrooperWeapon.RIFLE,1);
+        BasicTrooper t1 = new BasicTrooper(1,0,0, wm, TrooperWeapon.RIFLE,0);
+        BasicTrooper t2 = new BasicTrooper(2,10,0, wm, TrooperWeapon.RIFLE,1);
         Player p = new Player(1, "p");
         TacticalCoordinator coord = new TacticalCoordinator(List.of(t1, t2));
         coord.shareTarget(p);

--- a/client/app/src/test/java/com/tavuc/managers/InputManagerForcePowersTest.java
+++ b/client/app/src/test/java/com/tavuc/managers/InputManagerForcePowersTest.java
@@ -1,0 +1,49 @@
+package com.tavuc.managers;
+
+import com.tavuc.models.entities.Player;
+import com.tavuc.weapons.ForceAlignment;
+import com.tavuc.weapons.ForcePowers;
+import com.tavuc.weapons.WeaponStats;
+import com.tavuc.networking.models.PlayerJoinedBroadcast;
+import com.tavuc.Client;
+
+import org.junit.Test;
+import static org.junit.Assert.*;
+
+import java.awt.Canvas;
+import java.awt.event.KeyEvent;
+import java.io.PrintWriter;
+import java.io.StringWriter;
+
+public class InputManagerForcePowersTest {
+    @Test
+    public void pressingFKeysSendsAbilityRequests() throws Exception {
+        StringWriter sw = new StringWriter();
+        PrintWriter pw = new PrintWriter(sw, true);
+        java.lang.reflect.Field outField = Client.class.getDeclaredField("out");
+        outField.setAccessible(true);
+        outField.set(null, pw);
+
+        WorldManager wm = new WorldManager(0);
+        Client.worldManager = wm;
+        Player player = new Player(1, "tester");
+        wm.addPlayer(new PlayerJoinedBroadcast("2", "enemy", player.getX() + 1, player.getY(), 0, 0, 0));
+
+        InputManager im = InputManager.getInstance();
+        im.setPlayerTarget(player);
+        im.setControlTarget(InputManager.ControlTargetType.PLAYER);
+        ForcePowers fp = new ForcePowers(100, ForceAlignment.LIGHT, new WeaponStats(1, player.getAttackRange(), 0));
+        im.setForcePowers(fp);
+
+        Canvas c = new Canvas();
+        im.keyPressed(new KeyEvent(c, KeyEvent.KEY_PRESSED, System.currentTimeMillis(), 0, KeyEvent.VK_F1, KeyEvent.CHAR_UNDEFINED));
+        im.keyPressed(new KeyEvent(c, KeyEvent.KEY_PRESSED, System.currentTimeMillis(), 0, KeyEvent.VK_F2, KeyEvent.CHAR_UNDEFINED));
+        im.keyPressed(new KeyEvent(c, KeyEvent.KEY_PRESSED, System.currentTimeMillis(), 0, KeyEvent.VK_F3, KeyEvent.CHAR_UNDEFINED));
+
+        String out = sw.toString();
+        assertTrue(out.contains("FORCE_ABILITY_REQUEST"));
+        assertTrue(out.contains("FORCE_SLAM"));
+        assertTrue(out.contains("FORCE_PUSH"));
+        assertTrue(out.contains("FORCE_CHOKE"));
+    }
+}

--- a/client/app/src/test/java/com/tavuc/weapons/ForcePowersEnemyTargetTest.java
+++ b/client/app/src/test/java/com/tavuc/weapons/ForcePowersEnemyTargetTest.java
@@ -1,0 +1,40 @@
+package com.tavuc.weapons;
+
+import com.tavuc.models.entities.Player;
+import com.tavuc.managers.WorldManager;
+import com.tavuc.models.entities.enemies.BasicTrooper;
+import com.tavuc.models.entities.enemies.TrooperWeapon;
+import com.tavuc.weapons.ForceAlignment;
+import com.tavuc.weapons.ForcePowers;
+import com.tavuc.weapons.WeaponStats;
+import com.tavuc.Client;
+
+import java.io.PrintWriter;
+import java.io.StringWriter;
+
+import org.junit.Test;
+import static org.junit.Assert.*;
+
+public class ForcePowersEnemyTargetTest {
+    @Test
+    public void forceAbilitiesTargetEnemies() throws Exception {
+        StringWriter sw = new StringWriter();
+        PrintWriter pw = new PrintWriter(sw, true);
+        java.lang.reflect.Field outField = Client.class.getDeclaredField("out");
+        outField.setAccessible(true);
+        outField.set(null, pw);
+
+        WorldManager wm = new WorldManager(0);
+        Client.worldManager = wm;
+        Player player = new Player(1, "hero");
+        BasicTrooper enemy = new BasicTrooper(5, player.getX()+1, player.getY(), wm, TrooperWeapon.BLASTER,0);
+        wm.addEnemy(enemy);
+
+        ForcePowers fp = new ForcePowers(100, ForceAlignment.LIGHT, new WeaponStats(1, player.getAttackRange(), 0));
+        fp.primaryAttack(player, null); // should target enemy
+
+        String out = sw.toString();
+        assertTrue(out.contains("FORCE_ABILITY_REQUEST"));
+        assertTrue(out.contains("\"targetId\":\"5\""));
+    }
+}


### PR DESCRIPTION
## Summary
- add unique IDs to enemy classes and spawn them with WaveManager
- track enemies in `WorldManager`
- update `ForcePowers` to select enemies or players as targets
- extend `GameManager` so abilities damage enemies on the server
- test that abilities send requests when an enemy is targeted

## Testing
- `./run_all_tests.sh`

------
https://chatgpt.com/codex/tasks/task_e_68460e8d14f4833198147854b7da41fa