### PR TITLE
Add enemy wave networking

### DIFF
--- a/client/app/src/main/java/com/tavuc/Client.java
+++ b/client/app/src/main/java/com/tavuc/Client.java
@@ -48,6 +48,9 @@ import com.tavuc.networking.models.RegisterRequest;
 import com.tavuc.networking.models.RegisterResponse;
 import com.tavuc.networking.models.CoinDropSpawnedBroadcast;
 import com.tavuc.networking.models.CoinDropRemovedBroadcast;
+import com.tavuc.networking.models.EnemySpawnedBroadcast;
+import com.tavuc.networking.models.EnemyUpdateBroadcast;
+import com.tavuc.networking.models.EnemyRemovedBroadcast;
 import com.tavuc.networking.models.RequestChunkRequest;
 import com.tavuc.networking.models.RequestChunkResponse;
 import com.tavuc.networking.models.RequestPaletteRequest;
@@ -692,6 +695,24 @@ public class Client {
                                 if (currentSpacePanel != null) {
                                     ProjectileRemovedBroadcast event = gson.fromJson(processedJson, ProjectileRemovedBroadcast.class);
                                     SwingUtilities.invokeLater(() -> currentSpacePanel.handleProjectileRemoved(event));
+                                }
+                                break;
+                            case "ENEMY_SPAWNED_BROADCAST":
+                                if (worldManager != null) {
+                                    EnemySpawnedBroadcast event = gson.fromJson(processedJson, EnemySpawnedBroadcast.class);
+                                    SwingUtilities.invokeLater(() -> worldManager.handleEnemySpawned(event));
+                                }
+                                break;
+                            case "ENEMY_UPDATE_BROADCAST":
+                                if (worldManager != null) {
+                                    EnemyUpdateBroadcast event = gson.fromJson(processedJson, EnemyUpdateBroadcast.class);
+                                    SwingUtilities.invokeLater(() -> worldManager.handleEnemyUpdate(event));
+                                }
+                                break;
+                            case "ENEMY_REMOVED_BROADCAST":
+                                if (worldManager != null) {
+                                    EnemyRemovedBroadcast event = gson.fromJson(processedJson, EnemyRemovedBroadcast.class);
+                                    SwingUtilities.invokeLater(() -> worldManager.handleEnemyRemoved(event));
                                 }
                                 break;
                             case "COIN_DROP_SPAWNED_BROADCAST":

--- a/client/app/src/main/java/com/tavuc/managers/WorldManager.java
+++ b/client/app/src/main/java/com/tavuc/managers/WorldManager.java
@@ -14,6 +14,9 @@ import com.tavuc.networking.models.PlayerJoinedBroadcast; // Added import
 import com.tavuc.networking.models.PlayerMovedBroadcast; // Added import
 import com.tavuc.networking.models.CoinDropSpawnedBroadcast;
 import com.tavuc.networking.models.CoinDropRemovedBroadcast;
+import com.tavuc.networking.models.EnemySpawnedBroadcast;
+import com.tavuc.networking.models.EnemyUpdateBroadcast;
+import com.tavuc.networking.models.EnemyRemovedBroadcast;
 import com.tavuc.models.planets.Chunk;
 import com.tavuc.models.planets.ColorPallete;
 import com.tavuc.models.planets.ColorType;
@@ -53,6 +56,56 @@ public class WorldManager {
             enemies.put(e.getId(), e);
             if (Client.currentGamePanel != null) Client.currentGamePanel.repaint();
         }
+    }
+
+    /** Handle enemy spawned broadcast. */
+    public void handleEnemySpawned(EnemySpawnedBroadcast event) {
+        if (event == null) return;
+        int id;
+        try {
+            id = Integer.parseInt(event.enemyId);
+        } catch (NumberFormatException ex) {
+            return;
+        }
+        com.tavuc.models.entities.enemies.Enemy enemy = switch (event.enemyType) {
+            case "BasicTrooper" -> new com.tavuc.models.entities.enemies.BasicTrooper(id, event.x, event.y, this, com.tavuc.models.entities.enemies.TrooperWeapon.BLASTER, 0);
+            case "BasicMech" -> new com.tavuc.models.entities.enemies.BasicMech(id, event.x, event.y, this);
+            default -> null;
+        };
+        if (enemy != null) {
+            enemy.setHealth((int) event.health);
+            addEnemy(enemy);
+        }
+    }
+
+    /** Handle enemy update broadcast. */
+    public void handleEnemyUpdate(EnemyUpdateBroadcast event) {
+        if (event == null) return;
+        int id;
+        try {
+            id = Integer.parseInt(event.enemyId);
+        } catch (NumberFormatException ex) {
+            return;
+        }
+        com.tavuc.models.entities.enemies.Enemy enemy = enemies.get(id);
+        if (enemy != null) {
+            enemy.setX(event.x);
+            enemy.setY(event.y);
+            enemy.setDx(event.dx);
+            enemy.setDy(event.dy);
+            enemy.setDirection(event.direction);
+            enemy.setHealth((int) event.health);
+            if (Client.currentGamePanel != null) Client.currentGamePanel.repaint();
+        }
+    }
+
+    /** Handle enemy removal broadcast. */
+    public void handleEnemyRemoved(EnemyRemovedBroadcast event) {
+        if (event == null) return;
+        try {
+            int id = Integer.parseInt(event.enemyId);
+            removeEnemy(id);
+        } catch (NumberFormatException ignore) {}
     }
 
     public void removeEnemy(int id) {

--- a/client/app/src/main/java/com/tavuc/networking/models/EnemyRemovedBroadcast.java
+++ b/client/app/src/main/java/com/tavuc/networking/models/EnemyRemovedBroadcast.java
@@ -1,0 +1,9 @@
+package com.tavuc.networking.models;
+
+public class EnemyRemovedBroadcast extends BaseMessage {
+    public String enemyId;
+
+    public EnemyRemovedBroadcast() {
+        super();
+    }
+}

--- a/client/app/src/main/java/com/tavuc/networking/models/EnemySpawnedBroadcast.java
+++ b/client/app/src/main/java/com/tavuc/networking/models/EnemySpawnedBroadcast.java
@@ -1,0 +1,15 @@
+package com.tavuc.networking.models;
+
+public class EnemySpawnedBroadcast extends BaseMessage {
+    public String enemyId;
+    public String enemyType;
+    public int x;
+    public int y;
+    public int health;
+    public int width;
+    public int height;
+
+    public EnemySpawnedBroadcast() {
+        super();
+    }
+}

--- a/client/app/src/main/java/com/tavuc/networking/models/EnemyUpdateBroadcast.java
+++ b/client/app/src/main/java/com/tavuc/networking/models/EnemyUpdateBroadcast.java
@@ -1,0 +1,15 @@
+package com.tavuc.networking.models;
+
+public class EnemyUpdateBroadcast extends BaseMessage {
+    public String enemyId;
+    public int x;
+    public int y;
+    public double dx;
+    public double dy;
+    public double direction;
+    public double health;
+
+    public EnemyUpdateBroadcast() {
+        super();
+    }
+}

--- a/client/app/src/test/java/com/tavuc/managers/WorldManagerEnemyNetworkingTest.java
+++ b/client/app/src/test/java/com/tavuc/managers/WorldManagerEnemyNetworkingTest.java
@@ -1,0 +1,43 @@
+package com.tavuc.managers;
+
+import com.tavuc.networking.models.EnemySpawnedBroadcast;
+import com.tavuc.networking.models.EnemyUpdateBroadcast;
+import com.tavuc.networking.models.EnemyRemovedBroadcast;
+import org.junit.Test;
+import static org.junit.Assert.*;
+
+public class WorldManagerEnemyNetworkingTest {
+    @Test
+    public void enemySpawnUpdateRemoveFlow() {
+        WorldManager wm = new WorldManager(0);
+        EnemySpawnedBroadcast spawn = new EnemySpawnedBroadcast();
+        spawn.enemyId = "5";
+        spawn.enemyType = "BasicTrooper";
+        spawn.x = 10;
+        spawn.y = 20;
+        spawn.health = 3;
+        spawn.width = 20;
+        spawn.height = 20;
+        wm.handleEnemySpawned(spawn);
+        assertEquals(1, wm.getEnemies().size());
+
+        EnemyUpdateBroadcast update = new EnemyUpdateBroadcast();
+        update.enemyId = "5";
+        update.x = 15;
+        update.y = 25;
+        update.dx = 1;
+        update.dy = 1;
+        update.direction = 0.5;
+        update.health = 2;
+        wm.handleEnemyUpdate(update);
+        com.tavuc.models.entities.enemies.Enemy e = wm.getEnemies().get(0);
+        assertEquals(15, e.getX());
+        assertEquals(25, e.getY());
+        assertEquals(2, e.getHealth());
+
+        EnemyRemovedBroadcast rem = new EnemyRemovedBroadcast();
+        rem.enemyId = "5";
+        wm.handleEnemyRemoved(rem);
+        assertEquals(0, wm.getEnemies().size());
+    }
+}

--- a/server/app/src/main/java/com/tavuc/ai/WaveManager.java
+++ b/server/app/src/main/java/com/tavuc/ai/WaveManager.java
@@ -14,6 +14,7 @@ public class WaveManager {
     private List<WaveConfiguration> waves = new ArrayList<>();
     private int index = 0;
     private Instant waveStart;
+    private int nextId = 1;
 
     public void setWaves(List<WaveConfiguration> waves) {
         this.waves = waves;
@@ -34,10 +35,11 @@ public class WaveManager {
                 int[] pos = positions.get(i);
                 int x = pos[0];
                 int y = pos[1];
+                int id = nextId++;
                 if (data.type() == EnemyType.TROOPER) {
-                    spawned.add(new BasicTrooper(i, "t", x, y, TrooperWeapon.BLASTER, blocked, target, i));
+                    spawned.add(new BasicTrooper(id, "t", x, y, TrooperWeapon.BLASTER, blocked, target, i));
                 } else if (data.type() == EnemyType.MECH) {
-                    spawned.add(new BasicMech(i, "m", x, y, blocked, target));
+                    spawned.add(new BasicMech(id, "m", x, y, blocked, target));
                 }
             }
         }

--- a/server/app/src/main/java/com/tavuc/managers/GameManager.java
+++ b/server/app/src/main/java/com/tavuc/managers/GameManager.java
@@ -25,6 +25,9 @@ import com.tavuc.networking.models.PlayerKilledBroadcast;
 import com.tavuc.networking.models.CoinUpdateBroadcast;
 import com.tavuc.networking.models.CoinDropSpawnedBroadcast;
 import com.tavuc.networking.models.CoinDropRemovedBroadcast;
+import com.tavuc.networking.models.EnemySpawnedBroadcast;
+import com.tavuc.networking.models.EnemyUpdateBroadcast;
+import com.tavuc.networking.models.EnemyRemovedBroadcast;
 import com.tavuc.models.items.CoinDrop;
 import com.tavuc.models.entities.enemies.Enemy;
 import com.tavuc.models.space.BaseShip;   // Added import
@@ -50,6 +53,7 @@ public class GameManager {
     // Coin drop tracking
     private final ConcurrentMap<String, CoinDrop> coinDrops = new ConcurrentHashMap<>();
     private int nextCoinDropId = 1;
+
 
     // Wave and enemy tracking
     private WaveManager waveManager;
@@ -450,18 +454,34 @@ public class GameManager {
                     if (e.getHealth() <= 0) {
                         it.remove();
                         handleEnemyKilled(e, -1);
+                        broadcastToGame(new EnemyRemovedBroadcast(String.valueOf(e.getId())));
                     }
                 }
 
                 // Spawn next wave if needed
                 if ((activeEnemies.isEmpty() || waveManager.isCurrentWaveTimedOut()) && waveManager.hasMoreWaves()) {
                     Player target = players.get(0);
-                    activeEnemies.addAll(waveManager.spawnNextWave(blockedTiles, target));
+                    List<Enemy> spawned = waveManager.spawnNextWave(blockedTiles, target);
+                    activeEnemies.addAll(spawned);
+                    for (Enemy e : spawned) {
+                        broadcastToGame(new EnemySpawnedBroadcast(
+                                String.valueOf(e.getId()),
+                                e.getClass().getSimpleName(),
+                                e.getX(), e.getY(),
+                                (int)e.getHealth(),
+                                e.getWidth(), e.getHeight()));
+                    }
                 }
 
                 // Update active enemies
                 for (Enemy enemy : activeEnemies) {
                     enemy.update();
+                    broadcastToGame(new EnemyUpdateBroadcast(
+                            String.valueOf(enemy.getId()),
+                            enemy.getX(), enemy.getY(),
+                            enemy.getDx(), enemy.getDy(),
+                            enemy.getDirection(),
+                            enemy.getHealth()));
                 }
             }
 

--- a/server/app/src/main/java/com/tavuc/networking/models/EnemyRemovedBroadcast.java
+++ b/server/app/src/main/java/com/tavuc/networking/models/EnemyRemovedBroadcast.java
@@ -1,0 +1,11 @@
+package com.tavuc.networking.models;
+
+public class EnemyRemovedBroadcast extends BaseMessage {
+    public String enemyId;
+
+    public EnemyRemovedBroadcast(String enemyId) {
+        super();
+        this.type = "ENEMY_REMOVED_BROADCAST";
+        this.enemyId = enemyId;
+    }
+}

--- a/server/app/src/main/java/com/tavuc/networking/models/EnemySpawnedBroadcast.java
+++ b/server/app/src/main/java/com/tavuc/networking/models/EnemySpawnedBroadcast.java
@@ -1,0 +1,23 @@
+package com.tavuc.networking.models;
+
+public class EnemySpawnedBroadcast extends BaseMessage {
+    public String enemyId;
+    public String enemyType;
+    public int x;
+    public int y;
+    public int health;
+    public int width;
+    public int height;
+
+    public EnemySpawnedBroadcast(String enemyId, String enemyType, int x, int y, int health, int width, int height) {
+        super();
+        this.type = "ENEMY_SPAWNED_BROADCAST";
+        this.enemyId = enemyId;
+        this.enemyType = enemyType;
+        this.x = x;
+        this.y = y;
+        this.health = health;
+        this.width = width;
+        this.height = height;
+    }
+}

--- a/server/app/src/main/java/com/tavuc/networking/models/EnemyUpdateBroadcast.java
+++ b/server/app/src/main/java/com/tavuc/networking/models/EnemyUpdateBroadcast.java
@@ -1,0 +1,23 @@
+package com.tavuc.networking.models;
+
+public class EnemyUpdateBroadcast extends BaseMessage {
+    public String enemyId;
+    public int x;
+    public int y;
+    public double dx;
+    public double dy;
+    public double direction;
+    public double health;
+
+    public EnemyUpdateBroadcast(String enemyId, int x, int y, double dx, double dy, double direction, double health) {
+        super();
+        this.type = "ENEMY_UPDATE_BROADCAST";
+        this.enemyId = enemyId;
+        this.x = x;
+        this.y = y;
+        this.dx = dx;
+        this.dy = dy;
+        this.direction = direction;
+        this.health = health;
+    }
+}


### PR DESCRIPTION
## Summary
- define EnemySpawned/EnemyUpdate/EnemyRemoved network messages
- assign unique IDs to spawned enemies
- broadcast enemy spawns, updates, and removals from GameManager
- add WorldManager handlers for enemy networking
- forward new message types in Client
- test enemy networking flow

## Testing
- `./run_all_tests.sh`

------
https://chatgpt.com/codex/tasks/task_e_68461eb434fc8331898d677751e4f610