### PR TITLE
Improve ground movement controls

### DIFF
--- a/client/app/src/main/java/com/tavuc/managers/InputManager.java
+++ b/client/app/src/main/java/com/tavuc/managers/InputManager.java
@@ -262,23 +262,20 @@ public class InputManager implements KeyListener {
             return;
         }
 
-        double angle = player.getDirection();
-
+        // Ground movement no longer depends on the facing direction. The
+        // directional keys now map directly to world axes: W moves upward,
+        // S moves downward, A strafes left and D strafes right.
         if (upPressed && !downPressed) {
-            vecX += Math.cos(angle);
-            vecY += Math.sin(angle);
+            vecY -= 1;
         }
         if (downPressed && !upPressed) {
-            vecX -= Math.cos(angle);
-            vecY -= Math.sin(angle);
+            vecY += 1;
         }
         if (leftPressed && !rightPressed) {
-            vecX += Math.cos(angle - Math.PI / 2);
-            vecY += Math.sin(angle - Math.PI / 2);
+            vecX -= 1;
         }
         if (rightPressed && !leftPressed) {
-            vecX += Math.cos(angle + Math.PI / 2);
-            vecY += Math.sin(angle + Math.PI / 2);
+            vecX += 1;
         }
 
         boolean moving = vecX != 0 || vecY != 0;


### PR DESCRIPTION
## Summary
- update InputManager so ground movement is independent of facing direction
- map WASD directly to world axes: W forward, S backward, A/D strafe

## Testing
- `bash run_all_tests.sh`

------
https://chatgpt.com/codex/tasks/task_e_68462795b7208331ae77897a4f1e41fa